### PR TITLE
Feature/report options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/DEFRA/bwq-signage.svg?branch=master)](https://travis-ci.org/DEFRA/bwq-signage)
 [![Build Status](https://travis-ci.org/DEFRA/bwq-signage.svg?branch=develop)](https://travis-ci.org/DEFRA/bwq-signage)
-[![Coverage Status](https://coveralls.io/repos/github/DEFRA/bwq-signage/badge.svg?branch=develop)](https://coveralls.io/github/DEFRA/bwq-signage?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/DEFRA/bwq-signage/badge.svg?branch=develop&service=github)](https://coveralls.io/github/DEFRA/bwq-signage?branch=develop)
 
 # BWQ Signage project
 

--- a/app/assets/stylesheets/_grid.scss
+++ b/app/assets/stylesheets/_grid.scss
@@ -7,7 +7,7 @@
 .o-grid-row {
   @extend %grid-row;
 
-  .o-grid-column__third {
+  .o-grid-column__one-third {
     @include grid-column( 1/3 );
   }
 

--- a/app/controllers/signage_design_controller.rb
+++ b/app/controllers/signage_design_controller.rb
@@ -3,7 +3,7 @@
 # Main controller for showing the report design user interface
 class SignageDesignController < ApplicationController
   def show
-    options = { params: permitted_params }
+    options = { params: validate_params }
     options[:bathing_water] = BathingWater.new(params[:eubwid]) if params[:eubwid]
 
     @view_state = BwqSign.new(options)
@@ -11,7 +11,36 @@ class SignageDesignController < ApplicationController
 
   private
 
+  def validate_params
+    pp = permitted_params
+
+    validate_search(pp)
+    pp
+  end
+
   def permitted_params
     params.permit(*Workflow::ALL_PARAMS)
+  end
+
+  def validate_search(pp)
+    return unless (search_string = pp[:search])
+
+    if search_string.empty?
+      flash_message('Problem with search term', nil, ['Empty search input'])
+      pp.delete(:search)
+    elsif illegal_search_chars?(search_string)
+      flash_message('Problem with search term', nil, ['Non-permitted characters in search input'])
+      pp.delete(:search)
+    end
+  end
+
+  def illegal_search_chars?(search_string)
+    !search_string.match?(/\A(\w|\s|-)+\Z/)
+  end
+
+  def flash_message(title, message, errors)
+    flash[:title] = title if title
+    flash[:message] = message if message
+    flash[:errors] = errors if errors
   end
 end

--- a/app/controllers/signage_design_controller.rb
+++ b/app/controllers/signage_design_controller.rb
@@ -4,8 +4,8 @@
 class SignageDesignController < ApplicationController
   def show
     options = { params: validate_params }
-    options[:bathing_water] = BathingWater.new(params[:eubwid]) if params[:eubwid]
     options[:search] = search if params[:search]
+    options[:bathing_water] = load_bathing_water(params[:eubwid]) if params[:eubwid]
 
     @view_state = BwqSign.new(options)
   end
@@ -23,5 +23,9 @@ class SignageDesignController < ApplicationController
 
   def search
     @search ||= BathingWaterSearch.new
+  end
+
+  def load_bathing_water(eubwid)
+    BwqService.new.bathing_water_by_id(eubwid)
   end
 end

--- a/app/controllers/signage_design_controller.rb
+++ b/app/controllers/signage_design_controller.rb
@@ -5,6 +5,7 @@ class SignageDesignController < ApplicationController
   def show
     options = { params: validate_params }
     options[:bathing_water] = BathingWater.new(params[:eubwid]) if params[:eubwid]
+    options[:search] = search if params[:search]
 
     @view_state = BwqSign.new(options)
   end

--- a/app/controllers/signage_design_controller.rb
+++ b/app/controllers/signage_design_controller.rb
@@ -13,34 +13,14 @@ class SignageDesignController < ApplicationController
 
   def validate_params
     pp = permitted_params
-
-    validate_search(pp)
-    pp
+    search.validate(pp, flash)
   end
 
   def permitted_params
     params.permit(*Workflow::ALL_PARAMS)
   end
 
-  def validate_search(pp)
-    return unless (search_string = pp[:search])
-
-    if search_string.empty?
-      flash_message('Problem with search term', nil, ['Empty search input'])
-      pp.delete(:search)
-    elsif illegal_search_chars?(search_string)
-      flash_message('Problem with search term', nil, ['Non-permitted characters in search input'])
-      pp.delete(:search)
-    end
-  end
-
-  def illegal_search_chars?(search_string)
-    !search_string.match?(/\A(\w|\s|-)+\Z/)
-  end
-
-  def flash_message(title, message, errors)
-    flash[:title] = title if title
-    flash[:message] = message if message
-    flash[:errors] = errors if errors
+  def search
+    @search ||= BathingWaterSearch.new
   end
 end

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationJob < ActiveJob::Base
-end

--- a/app/lib/bwq_service.rb
+++ b/app/lib/bwq_service.rb
@@ -17,6 +17,7 @@ class BwqService < LdaApi
     latestProfile.pollutionRiskForecasting
     latestProfile.seasonStartDate
     latestProfile.seasonFinishDate
+    latestProfile.controllerName
     latestComplianceAssessment.sampleYear.ordinalYear
     latestRiskPrediction.*
   ].join(',')

--- a/app/lib/bwq_service.rb
+++ b/app/lib/bwq_service.rb
@@ -40,12 +40,11 @@ class BwqService < LdaApi
   end
 
   # Return a list of all known bathing waters. List is cached for future re-use
-  def all_bathing_waters(country = ENGLAND_URI)
+  def all_bathing_waters(options = {})
     if bws_by_uri.empty?
-      options = { _pageSize: 600 }
-      options[:country] = country unless country == :all
+      api_options = { _pageSize: 600 }.merge(options)
 
-      bws = api_get_resources(BathingWater.endpoint_all, ALL_PAGES, BathingWater, options)
+      bws = api_get_resources(BathingWater.endpoint_all, ALL_PAGES, BathingWater, api_options)
       bws.each do |bw|
         bws_by_uri[bw.uri] = bw
         bws_by_id[bw.id] = bw
@@ -56,8 +55,8 @@ class BwqService < LdaApi
   end
 
   # Perform block for each bathing water in the list of all bathing waters
-  def each_bathing_water(&block)
-    all_bathing_waters.each(&block)
+  def each_bathing_water(options = {}, &block)
+    all_bathing_waters(options).each(&block)
   end
 
   # Return the description of a bathing water, given its eubwid

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-# :nodoc:
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end

--- a/app/models/bathing_water.rb
+++ b/app/models/bathing_water.rb
@@ -16,4 +16,8 @@ class BathingWater < LdaResource
   def eubwid
     self['eubwidNotation']
   end
+
+  def controller_name
+    self['latestProfile.controllerName']
+  end
 end

--- a/app/presenters/bwq_sign.rb
+++ b/app/presenters/bwq_sign.rb
@@ -2,19 +2,29 @@
 
 # Presenter for view state for bathing water signs
 class BwqSign
+  attr_reader :options
+
   def initialize(options)
     @options = options
   end
 
   def bathing_water
-    @options[:bathing_water]
+    options[:bathing_water]
   end
 
   def params
-    @options[:params]
+    options[:params]
   end
 
   def next_workflow_step
     Workflow.next_step(params)
+  end
+
+  def search_term
+    params[:search]
+  end
+
+  def search_results
+    @search_results ||= options[:search].search(search_term)
   end
 end

--- a/app/presenters/workflow.rb
+++ b/app/presenters/workflow.rb
@@ -17,10 +17,10 @@ class Workflow
     { has: %i[design eubwid], missing: %i[bwmgr-name], name: :bwmgr },
     { has: %i[design eubwid], missing: %i[bwmgr-phone], name: :bwmgr },
     { has: %i[design eubwid], missing: %i[bwmgr-email], name: :bwmgr },
-    { has: %i[design eubwid bwmgr-name], missing: %i[no-hist], name: :opts },
-    { has: %i[design eubwid bwmgr-name], missing: %i[no-map], name: :opts },
-    { has: %i[design eubwid bwmgr-name], missing: %i[no-prf], name: :opts },
-    { has: %i[design eubwid bwmgr-name], missing: %i[no-logo], name: :opts },
+    { has: %i[design eubwid bwmgr-name], missing: %i[show-prf], name: :opts },
+    { has: %i[design eubwid bwmgr-name], missing: %i[show-map], name: :opts },
+    { has: %i[design eubwid bwmgr-name], missing: %i[show-hist], name: :opts },
+    { has: %i[design eubwid bwmgr-name], missing: %i[show-logo], name: :opts },
     { has: %i[], missing: %i[design], name: :landing },
     { has: [], missing: [], name: :preview }
   ].freeze

--- a/app/services/bathing_water_search.rb
+++ b/app/services/bathing_water_search.rb
@@ -1,0 +1,41 @@
+# frozen-string-literal: true
+
+# A simple lookup service for finding bathing waters by name, EUBWID or bathing
+# water controller name
+class BathingWaterSearch
+  # Search for a term that may be part of a bathing water name, a bathing water
+  # ID or a bathing water controller
+  def search(term)
+    #
+  end
+
+  def validate(params, flash)
+    return params unless (search_string = params[:search])
+
+    if search_string.empty?
+      message(flash, 'Problem with search term', nil, ['Empty search input'])
+      params.delete(:search)
+    elsif illegal_search_chars?(search_string)
+      message(flash, 'Problem with search term', nil, ['Non-permitted characters in search input'])
+      params.delete(:search)
+    end
+
+    params
+  end
+
+  private
+
+  def illegal_search_chars?(search_string)
+    !search_string.match?(/\A(\w|\s|-)+\Z/)
+  end
+
+  def api
+    @api ||= BwqService.new
+  end
+
+  def message(flash, title, message, errors)
+    flash[:title] = title if title
+    flash[:message] = message if message
+    flash[:errors] = errors if errors
+  end
+end

--- a/app/services/bathing_water_search.rb
+++ b/app/services/bathing_water_search.rb
@@ -3,10 +3,19 @@
 # A simple lookup service for finding bathing waters by name, EUBWID or bathing
 # water controller name
 class BathingWaterSearch
+  API_OPTIONS = { _properties: ['latestProfile.controllerName'].join(',') }.freeze
+
   # Search for a term that may be part of a bathing water name, a bathing water
   # ID or a bathing water controller
   def search(term)
-    #
+    results = {
+      by_name: [],
+      by_id: [],
+      by_controller: []
+    }
+
+    api.each_bathing_water(API_OPTIONS) { |bw| search_bathing_water(bw, term, results) }
+    results
   end
 
   def validate(params, flash)
@@ -37,5 +46,15 @@ class BathingWaterSearch
     flash[:title] = title if title
     flash[:message] = message if message
     flash[:errors] = errors if errors
+  end
+
+  def search_bathing_water(bw, term, results) # rubocop:disable Metrics/AbcSize
+    lc_term = term.downcase
+
+    results[:by_name] << bw if bw.name.downcase.include?(lc_term)
+    results[:by_id] << bw if bw.eubwid.include?(lc_term)
+
+    return unless (controller_name = bw['latestProfile.controllerName'])
+    results[:by_controller] << bw if controller_name.downcase.include?(lc_term)
   end
 end

--- a/app/views/signage_design/_bwmgr.html.haml
+++ b/app/views/signage_design/_bwmgr.html.haml
@@ -1,0 +1,33 @@
+.o-workflow-unit.o-workflow-unit__landing
+  .o-grid-row
+    .o-grid-column__two-thirds
+
+      %h2.heading-medium
+        Bathing water manager information for #{@view_state.bathing_water.name}
+      %p.lede
+        The sign should tell members of the public who manages this bathing water,
+        and how they can get in touch if needed.
+
+      %p
+        You can add a logo or other identifying image on the next screen.
+
+      = render partial: 'warning_flash'
+
+      = form_tag(root_path, method: 'get', enforce_utf8: false) do
+        = hidden_field_tag(:design, true)
+        = hidden_field_tag(:eubwid, @view_state.bathing_water.eubwid)
+
+        .form-group
+          = label_tag(:'bwmgr-name', 'Bathing water is managed by', { class: 'form-label-bold' })
+          = text_field_tag(:'bwmgr-name', @view_state.bathing_water.controller_name, { class: 'form-control-2-3' })
+
+        .form-group
+          = label_tag(:'bwmgr-email', 'Contact email address', { class: 'form-label-bold' })
+          = email_field_tag(:'bwmgr-email', nil, { class: 'form-control-2-3' })
+
+        .form-group
+          = label_tag(:'bwmgr-name', 'Contact phone number', { class: 'form-label-bold' })
+          = telephone_field_tag(:'bwmgr-phone', nil, { class: 'form-control-2-3' })
+
+        .form-group
+          = submit_tag('Next step', { class: 'button' })

--- a/app/views/signage_design/_landing.html.haml
+++ b/app/views/signage_design/_landing.html.haml
@@ -16,4 +16,4 @@
         format to be printed on paper or other media.
 
       %p
-        = link_to('Start now', '#', class: 'button button-start')
+        = link_to('Start now', root_path(design: true), class: 'button button-start')

--- a/app/views/signage_design/_opts.html.haml
+++ b/app/views/signage_design/_opts.html.haml
@@ -1,0 +1,26 @@
+.o-workflow-unit.o-workflow-unit__landing
+  .o-grid-row
+    .o-grid-column__two-thirds
+
+      %h2.heading-medium
+        Bathing water sign options
+      %p.lede
+        You can select which elements of the sign you would like to include.
+
+      = render partial: 'warning_flash'
+
+      = form_tag(root_path, method: 'get', enforce_utf8: false) do
+        = hidden_field_tag(:design, true)
+        = hidden_field_tag(:eubwid, @view_state.bathing_water.eubwid)
+
+        - %i[bwmgr-name bwmgr-phone bwmgr-email].each do |param|
+          = hidden_field_tag(param, @view_state.params[param])
+
+        = render partial: 'yes_no_option', locals: { option_heading: 'Include pollution risk forecast information?', option_var: 'show-prf', option_default: 'yes' }
+        = render partial: 'yes_no_option', locals: { option_heading: 'Show the history of previous annual classifications?', option_var: 'show-hist', option_default: 'yes' }
+        = render partial: 'yes_no_option', locals: { option_heading: 'Show a map of the sampling point location?', option_var: 'show-map', option_default: 'yes' }
+        = render partial: 'yes_no_option', locals: { option_heading: 'Include the Environment Agency logo?', option_var: 'show-logo', option_default: 'yes' }
+
+        .form-group
+          %p
+            = submit_tag('Next step', { class: 'button' })

--- a/app/views/signage_design/_search.html.haml
+++ b/app/views/signage_design/_search.html.haml
@@ -1,0 +1,1 @@
+%p Search

--- a/app/views/signage_design/_search.html.haml
+++ b/app/views/signage_design/_search.html.haml
@@ -8,6 +8,8 @@
         Search for a bathing water by name, by bathing-water ID or by the name
         of the bathing water controller.
 
+      = render partial: 'warning_flash'
+
       = form_tag(root_path(design: true), method: 'get', enforce_utf8: false) do
         = hidden_field_tag(:design, true)
 

--- a/app/views/signage_design/_search.html.haml
+++ b/app/views/signage_design/_search.html.haml
@@ -1,1 +1,19 @@
-%p Search
+.o-workflow-unit.o-workflow-unit__landing
+  .o-grid-row
+    .o-grid-column__two-thirds
+
+      %h2.heading-medium
+        Which bathing water?
+      %p.lede
+        Search for a bathing water by name, by bathing-water ID or by the name
+        of the bathing water controller.
+
+      = form_tag(root_path(design: true), method: 'get', enforce_utf8: false) do
+        = hidden_field_tag(:design, true)
+
+        .form-group
+          = label_tag(:search, 'Bathing water name, EUBWID, or controller name', { class: 'form-label-bold' })
+          = search_field_tag(:search, nil, { class: 'form-control-2-3' })
+
+        .form-group
+          = submit_tag('Search', { class: 'button' })

--- a/app/views/signage_design/_select.html.haml
+++ b/app/views/signage_design/_select.html.haml
@@ -1,0 +1,1 @@
+%p Search results

--- a/app/views/signage_design/_select.html.haml
+++ b/app/views/signage_design/_select.html.haml
@@ -1,1 +1,52 @@
-%p Search results
+.o-workflow-unit.o-workflow-unit__search-results
+  .o-grid-row
+    .o-grid-column__two-thirds
+
+      %h2.heading-medium
+        Search results for &quot;#{@view_state.search_term}&quot;
+
+      %p
+        Select one of the results below, or
+        = link_to('search again', root_path(design: true))
+
+
+  .o-grid-row
+    - name_results = @view_state.search_results[:by_name]
+    - id_results = @view_state.search_results[:by_id]
+    - controller_results = @view_state.search_results[:by_controller]
+
+    - if name_results.empty? &&  id_results.empty? && controller_results.empty?
+      .o-grid-column__two-thirds
+        .error-summary{ role: 'alert', aria: { labelledby: 'error-summary-no-results' }, tabindex: '-1' }
+          %h3#error-summary-no-results
+            Sorry, there were no matching locations for that search.
+
+    - unless name_results.empty?
+      .o-grid-column__one-third
+        %h3.heading-small
+          Matching bathing water names
+
+        %ul.o-search-results
+          - name_results.each do |bw|
+            %li.o-search-results__result
+              = link_to(bw.name, root_path(design: true, eubwid: bw.eubwid))
+
+    - unless id_results.empty?
+      .o-grid-column__one-third
+        %h3.heading-small
+          Matching bathing water identifiers
+
+        %ul.o-search-results
+          - id_results.each do |bw|
+            %li.o-search-results__result
+              = link_to("#{bw.name} (#{bw.eubwid})", root_path(design: true, eubwid: bw.eubwid))
+
+    - unless controller_results.empty?
+      .o-grid-column__one-third
+        %h3.heading-small
+          Matching controller names
+
+        %ul.o-search-results
+          - controller_results.each do |bw|
+            %li.o-search-results__result
+              = link_to("#{bw.name} (#{bw.controller_name})", root_path(design: true, eubwid: bw.eubwid))

--- a/app/views/signage_design/_warning_flash.html.haml
+++ b/app/views/signage_design/_warning_flash.html.haml
@@ -1,0 +1,14 @@
+- if flash && !flash.empty?
+  #c-flash.error-summary{ role: 'alert', aria: { labelledby: 'error-summary-heading-example-1' }, tabindex: '-1' }
+    %h2.heading-medium.error-summary-heading
+      = flash[:title]
+
+    - if flash[:message]
+      %p
+        = flash[:message]
+
+    - if flash[:errors]
+      %ul.error-summary-list
+        - flash[:errors].each do |error|
+          %li
+            = error

--- a/app/views/signage_design/_yes_no_option.html.haml
+++ b/app/views/signage_design/_yes_no_option.html.haml
@@ -1,0 +1,12 @@
+- value = params.key?(option_var) ? params[option_var] : option_default
+
+.fieldset
+  %legend
+    %h3.heading-small
+      = option_heading
+
+    .multiple-choice
+      = radio_button_tag(:"#{option_var}", 'yes', value == 'yes')
+      = label_tag(:"#{option_var}_yes", 'Yes')
+      = radio_button_tag(:"#{option_var}", 'no', value == 'no')
+      = label_tag(:"#{option_var}_no", 'No')

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -30,4 +30,10 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     find('.button-start')
       .must_have_content('Start now')
   end
+
+  it 'should navigate to the first step in the workflow' do
+    visit(root_path)
+    click_on(class: 'button-start')
+    page.must_have_current_path(root_path(design: true))
+  end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -36,4 +36,11 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     click_on(class: 'button-start')
     page.must_have_current_path(root_path(design: true))
   end
+
+  it 'should allow the user to enter a search term' do
+    visit(root_path(design: true))
+    fill_in('search', with: 'cleve')
+    click_on('Search')
+    page.must_have_content('Search results')
+  end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -98,4 +98,23 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
       find('#bwmgr-name').value.must_equal('North Somerset')
     end
   end
+
+  it 'shows the sign options with default values selected' do
+    VCR.use_cassette('bathing_water_clevedon_lookup') do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000', 'bwmgr-name': 'North Somerset',
+                      'bwmgr-phone': '', 'bwmgr-email': ''))
+      page.must_have_content('Bathing water sign options')
+      find('legend', text: 'Include pollution risk forecast information?')
+      find(:radio_button, :'show-prf', checked: true).value.must_equal('yes')
+    end
+  end
+
+  it 'shows the sign options with a non-default value selected' do
+    VCR.use_cassette('bathing_water_clevedon_lookup') do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000', 'bwmgr-name': 'North Somerset',
+                      'bwmgr-phone': '', 'bwmgr-email': '', 'show-prf': 'no'))
+      page.must_have_content('Bathing water sign options')
+      find(:radio_button, :'show-prf', checked: true).value.must_equal('no')
+    end
+  end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -38,10 +38,12 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
   end
 
   it 'should allow the user to enter a search term' do
-    visit(root_path(design: true))
-    fill_in('search', with: 'cleve')
-    click_on('Search')
-    page.must_have_content('Search results')
+    VCR.use_cassette('bathing_waters_api') do
+      visit(root_path(design: true))
+      fill_in('search', with: 'cleve')
+      click_on('Search')
+      page.must_have_content('Search results')
+    end
   end
 
   it 'should reject an empty search term' do
@@ -57,5 +59,29 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     click_on('Search')
     page.wont_have_content('Search results')
     find('.error-summary').must_have_content('Non-permitted characters in search input')
+  end
+
+  it 'should list results on a term that matches bathing waters and controllers' do
+    VCR.use_cassette('bathing_waters_api') do
+      visit(root_path(design: true, search: 'cleve'))
+      page.must_have_content('Search results for "cleve"')
+      find('.o-search-results__result', text: 'Clevedon Beach')
+      find('.o-search-results__result', text: 'Redcar Lifeboat Station (Redcar and Cleveland)')
+    end
+  end
+
+  it 'should list results for a term that matches a bathing water ID' do
+    VCR.use_cassette('bathing_waters_api') do
+      visit(root_path(design: true, search: 'ukk1202'))
+      page.must_have_content('Search results for "ukk1202"')
+      find('.o-search-results__result', text: 'Clevedon Beach')
+    end
+  end
+
+  it 'should show an error message when there are no matching search results' do
+    VCR.use_cassette('bathing_waters_api') do
+      visit(root_path(design: true, search: 'womble'))
+      page.must_have_content('Sorry, there were no matching locations for that search.')
+    end
   end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -84,4 +84,18 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
       page.must_have_content('Sorry, there were no matching locations for that search.')
     end
   end
+
+  it 'should show the next step in the process when the user selects a bathing water' do
+    VCR.use_cassette('bathing_water_clevedon_lookup') do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000'))
+      page.must_have_content('Bathing water manager information for Clevedon Beach')
+    end
+  end
+
+  it 'select the name of the bathing water controller by default' do
+    VCR.use_cassette('bathing_water_clevedon_lookup') do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000'))
+      find('#bwmgr-name').value.must_equal('North Somerset')
+    end
+  end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -43,4 +43,19 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     click_on('Search')
     page.must_have_content('Search results')
   end
+
+  it 'should reject an empty search term' do
+    visit(root_path(design: true))
+    click_on('Search')
+    page.wont_have_content('Search results')
+    find('.error-summary').must_have_content('Empty search input')
+  end
+
+  it 'should reject a search term with punctuation' do
+    visit(root_path(design: true))
+    fill_in('search', with: '; drop table')
+    click_on('Search')
+    page.wont_have_content('Search results')
+    find('.error-summary').must_have_content('Non-permitted characters in search input')
+  end
 end

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -92,7 +92,7 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  it 'select the name of the bathing water controller by default' do
+  it 'selects the name of the bathing water controller by default' do
     VCR.use_cassette('bathing_water_clevedon_lookup') do
       visit(root_path(design: true, eubwid: 'ukk1202-36000'))
       find('#bwmgr-name').value.must_equal('North Somerset')

--- a/test/fixtures/files/bathing-water.json
+++ b/test/fixtures/files/bathing-water.json
@@ -2,9 +2,9 @@
   "format": "linked-data-api",
   "version": "0.2",
   "result": {
-    "_about": "http://environment.data.gov.uk/doc/bathing-water/ukk1202-36000.json",
-    "definition": "http://environment.data.gov.uk/meta/doc/bathing-water/_eubwid.json",
-    "extendedMetadataVersion": "http://environment.data.gov.uk/doc/bathing-water/ukk1202-36000.json?_metadata=all",
+    "_about": "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestProfile.controllerName",
+    "definition": "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestProfile.controllerName",
+    "extendedMetadataVersion": "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestProfile.controllerName&_metadata=all",
     "primaryTopic": {
       "_about": "http://environment.data.gov.uk/id/bathing-water/ukk1202-36000",
       "appointedSewerageUndertaker": {
@@ -51,7 +51,7 @@
       },
       "eubwidNotation": "ukk1202-36000",
       "latestComplianceAssessment": {
-        "_about": "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/36000/year/2017",
+        "_about": "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/36000/year/2016",
         "complianceClassification": {
           "_about": "http://environment.data.gov.uk/def/bwq-cc-2015/2",
           "name": {
@@ -60,22 +60,25 @@
           }
         }
       },
-      "latestProfile": "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1",
+      "latestProfile": {
+        "_about": "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1",
+        "controllerName": "North Somerset"
+      },
       "latestRiskPrediction": {
-        "_about": "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/36000/date/20170930-084612",
+        "_about": "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/36000/date/20171006-144034",
         "expiresAt": {
-          "_value": "2017-10-01T08:29:00",
+          "_value": "2017-10-07T08:29:00",
           "_datatype": "dateTime"
         },
         "riskLevel": {
-          "_about": "http://environment.data.gov.uk/def/bwq-stp/increased",
+          "_about": "http://environment.data.gov.uk/def/bwq-stp/normal",
           "name": {
-            "_value": "increased",
+            "_value": "normal",
             "_lang": "en"
           }
         }
       },
-      "latestSampleAssessment": "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/36000/date/20170922/time/104000/recordDate/20170922",
+      "latestSampleAssessment": "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/36000/date/20160922/time/100400/recordDate/20160922",
       "name": {
         "_value": "Clevedon Beach",
         "_lang": "en"

--- a/test/fixtures/vcr_cassettes/bathing_water_clevedon_lookup.yml
+++ b/test/fixtures/vcr_cassettes/bathing_water_clevedon_lookup.yml
@@ -20,24 +20,26 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
+      Age:
+      - '75'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 21:36:26 GMT
+      - Fri, 02 Feb 2018 21:37:40 GMT
       Etag:
       - '"aca12b6eb0f4bada-gzip"'
       Expires:
       - Fri, 02 Feb 2018 21:39:26 GMT
       Server:
-      - Server
+      - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
       - '160'
-      Transfer-Encoding:
-      - chunked
+      Content-Length:
+      - '1717'
       Connection:
       - keep-alive
     body:
@@ -88,5 +90,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 21:36:27 GMT
+  recorded_at: Fri, 02 Feb 2018 21:37:40 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/bathing_waters_api.yml
+++ b/test/fixtures/vcr_cassettes/bathing_waters_api.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:52 GMT
+      - Fri, 02 Feb 2018 17:26:43 GMT
       Etag:
       - '"ccc788b3d2ae89ab-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:51 GMT
+      - Fri, 02 Feb 2018 17:29:41 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '121'
+      - '144'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -11292,5 +11292,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:52 GMT
+  recorded_at: Fri, 02 Feb 2018 17:26:43 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/bathing_waters_api.yml
+++ b/test/fixtures/vcr_cassettes/bathing_waters_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestProfile.controllerName
     body:
       encoding: US-ASCII
       string: ''
@@ -20,32 +20,30 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '1'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_properties=latestProfile.controllerName
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 15:39:52 GMT
       Etag:
-      - '"ea2bf6b49f898e6-gzip"'
+      - '"ccc788b3d2ae89ab-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 15:42:51 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
-      Content-Length:
-      - '57852'
+      - '121'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_properties=latestProfile.controllerName", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?_properties=latestProfile.controllerName", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_properties=latestProfile.controllerName&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0&_properties=latestProfile.controllerName", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_properties=latestProfile.controllerName", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?_properties=latestProfile.controllerName", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_properties=latestProfile.controllerName", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
@@ -59,7 +57,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2102-03600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/03600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/03600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "controllerName" : "Northumberland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/03600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -86,7 +85,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2102-03700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/03700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03700/date/20160919/time/104900/recordDate/20160919", "name" : {"_value" : "Bamburgh Castle", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03700/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03700/date/20160919/time/104900/recordDate/20160919", "name" : {"_value" : "Bamburgh Castle", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bamburgh-castle", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/03700", "easting" : 418500.0, "lat" : 55.6109624803421, "long" : -1.70790347736216, "name" : {"_value" : "Sampling point at Bamburgh Castle", "_lang" : "en"}
@@ -109,7 +109,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2102-03800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/03800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03800/date/20160919/time/110300/recordDate/20160919", "name" : {"_value" : "Seahouses North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03800/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03800/date/20160919/time/110300/recordDate/20160919", "name" : {"_value" : "Seahouses North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/seahouses-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/03800", "easting" : 421100.0, "lat" : 55.5901915983294, "long" : -1.66680589716163, "name" : {"_value" : "Sampling point at Seahouses North", "_lang" : "en"}
@@ -132,7 +133,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2102-03900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/03900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03900/date/20160919/time/112500/recordDate/20160919", "name" : {"_value" : "Beadnell", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03900/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/03900/date/20160919/time/112500/recordDate/20160919", "name" : {"_value" : "Beadnell", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/beadnell", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/03900", "easting" : 423300.0, "lat" : 55.5487603048552, "long" : -1.63228751096927, "name" : {"_value" : "Sampling point at Beadnell", "_lang" : "en"}
@@ -155,7 +157,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2101-04000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04000/date/20160919/time/114900/recordDate/20160919", "name" : {"_value" : "Low Newton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04000/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04000/date/20160919/time/114900/recordDate/20160919", "name" : {"_value" : "Low Newton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/low-newton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04000", "easting" : 424380.0, "lat" : 55.5132163987303, "long" : -1.61551676459494, "name" : {"_value" : "Sampling point at Low Newton", "_lang" : "en"}
@@ -178,7 +181,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2101-04200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04200/date/20160919/time/122900/recordDate/20160919", "name" : {"_value" : "Warkworth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04200/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04200/date/20160919/time/122900/recordDate/20160919", "name" : {"_value" : "Warkworth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/warkworth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04200", "easting" : 425920.0, "lat" : 55.3512136840278, "long" : -1.59280027513502, "name" : {"_value" : "Sampling point at Warkworth", "_lang" : "en"}
@@ -201,7 +205,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2101-04250", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04250/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04250/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04250/date/20160919/time/124900/recordDate/20160919", "name" : {"_value" : "Amble Links", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2101-04250/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04250/date/20160919/time/124900/recordDate/20160919", "name" : {"_value" : "Amble Links", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/amble-links", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04250", "easting" : 428500.0, "lat" : 55.3256518430612, "long" : -1.55240065878181, "name" : {"_value" : "Sampling point at Amble Links", "_lang" : "en"}
@@ -224,7 +229,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2104-04280", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04280/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2104-04280/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04280/date/20160919/time/131400/recordDate/20160919", "name" : {"_value" : "Druridge Bay North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2104-04280/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04280/date/20160919/time/131400/recordDate/20160919", "name" : {"_value" : "Druridge Bay North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/druridge-bay-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04280", "easting" : 427500.0, "lat" : 55.2911145717199, "long" : -1.56853575551603, "name" : {"_value" : "Sampling point at Druridge Bay North", "_lang" : "en"}
@@ -247,7 +253,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2104-04300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2104-04300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04300/date/20160919/time/134000/recordDate/20160919", "name" : {"_value" : "Druridge Bay South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2104-04300/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04300/date/20160919/time/134000/recordDate/20160919", "name" : {"_value" : "Druridge Bay South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/druridge-bay-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04300", "easting" : 429100.0, "lat" : 55.2402551088777, "long" : -1.54392384292723, "name" : {"_value" : "Sampling point at Druridge Bay South", "_lang" : "en"}
@@ -270,7 +277,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2106-04400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2106-04400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04400/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2106-04400/2017:1", "controllerName" : "Northumberland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04400/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -297,7 +305,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2106-04500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2106-04500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04500/date/20160919/time/141600/recordDate/20160919", "name" : {"_value" : "Newbiggin South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2106-04500/2017:1", "controllerName" : "Northumberland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04500/date/20160919/time/141600/recordDate/20160919", "name" : {"_value" : "Newbiggin South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/newbiggin-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04500", "easting" : 431000.0, "lat" : 55.1788586358132, "long" : -1.51479031216353, "name" : {"_value" : "Sampling point at Newbiggin South", "_lang" : "en"}
@@ -320,7 +329,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2103-04600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2103-04600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2103-04600/2017:1", "controllerName" : "Northumberland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -347,7 +357,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2103-04700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2103-04700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2103-04700/2017:1", "controllerName" : "Northumberland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -374,7 +385,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2203-04800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-04800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04800/date/20160920/time/110500/recordDate/20160920", "name" : {"_value" : "Whitley Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-04800/2017:1", "controllerName" : "North Tyneside"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/04800/date/20160920/time/110500/recordDate/20160920", "name" : {"_value" : "Whitley Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/whitley-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/04800", "easting" : 435550.0, "lat" : 55.0488919996071, "long" : -1.44514764351662, "name" : {"_value" : "Sampling point at Whitley Bay", "_lang" : "en"}
@@ -397,7 +409,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2203-04900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/04900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-04900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-04900/2017:1", "controllerName" : "North Tyneside"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/04900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -424,7 +437,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2203-05000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05000/date/20160920/time/113000/recordDate/20160920", "name" : {"_value" : "Tynemouth Long Sands North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05000/2017:1", "controllerName" : "North Tyneside"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05000/date/20160920/time/113000/recordDate/20160920", "name" : {"_value" : "Tynemouth Long Sands North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/tynemouth-long-sands-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/05000", "easting" : 436619.0, "lat" : 55.0304210257448, "long" : -1.4286789481503, "name" : {"_value" : "Sampling point at Tynemouth Long Sands North", "_lang" : "en"}
@@ -447,7 +461,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2203-05100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05100/date/20160920/time/115000/recordDate/20160920", "name" : {"_value" : "Tynemouth Long Sands South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05100/2017:1", "controllerName" : "North Tyneside"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05100/date/20160920/time/115000/recordDate/20160920", "name" : {"_value" : "Tynemouth Long Sands South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/tynemouth-long-sands-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/05100", "easting" : 436970.0, "lat" : 55.024078226215, "long" : -1.42327882219309, "name" : {"_value" : "Sampling point at Tynemouth Long Sands South", "_lang" : "en"}
@@ -470,7 +485,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2203-05200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05200/date/20160920/time/120000/recordDate/20160920", "name" : {"_value" : "Tynemouth King Edwards Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2203-05200/2017:1", "controllerName" : "North Tyneside"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05200/date/20160920/time/120000/recordDate/20160920", "name" : {"_value" : "Tynemouth King Edwards Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/tynemouth-king-edwards-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/05200", "easting" : 437248.0, "lat" : 55.0193221136079, "long" : -1.41899913650401, "name" : {"_value" : "Sampling point at Tynemouth King Edwards Bay", "_lang" : "en"}
@@ -493,7 +509,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2204-05300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2204-05300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05300/date/20160920/time/125500/recordDate/20160920", "name" : {"_value" : "South Shields", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2204-05300/2017:1", "controllerName" : "South Tyneside"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/05300/date/20160920/time/125500/recordDate/20160920", "name" : {"_value" : "South Shields", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/south-shields", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/05300", "easting" : 437900.0, "lat" : 54.9997471932089, "long" : -1.4090895613675, "name" : {"_value" : "Sampling point at South Shields", "_lang" : "en"}
@@ -516,7 +533,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2204-05400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2204-05400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2204-05400/2017:1", "controllerName" : "South Tyneside"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -543,7 +561,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2300-05500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2300-05500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2300-05500/2017:1", "controllerName" : "Sunderland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -570,7 +589,8 @@ http_interactions:
               , "eubwidNotation" : "ukc2300-05600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2300-05600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2300-05600/2017:1", "controllerName" : "Sunderland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -597,7 +617,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1404-05700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05700/2017:1", "controllerName" : "County Durham"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -624,7 +645,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1404-05800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05800/2017:1", "controllerName" : "County Durham"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -651,7 +673,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1404-05900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/05900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1404-05900/2017:1", "controllerName" : "County Durham"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/05900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -678,7 +701,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1101-06000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06000/2017:1", "controllerName" : "Hartlepool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -705,7 +729,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1101-06100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06100/2017:1", "controllerName" : "Hartlepool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -732,7 +757,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1101-06200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/06200/date/20160919/time/150000/recordDate/20160919", "name" : {"_value" : "Seaton Carew North Gare", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1101-06200/2017:1", "controllerName" : "Hartlepool"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/06200/date/20160919/time/150000/recordDate/20160919", "name" : {"_value" : "Seaton Carew North Gare", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/seaton-carew-north-gare", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/06200", "easting" : 454000.0, "lat" : 54.6496298348782, "long" : -1.16466146681862, "name" : {"_value" : "Sampling point at Seaton Carew North Gare", "_lang" : "en"}
@@ -755,7 +781,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06300/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -782,7 +809,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06400/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -809,7 +837,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06500/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -836,7 +865,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06600/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -863,7 +893,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06650/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06650/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06650/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06650/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -890,7 +921,8 @@ http_interactions:
               , "eubwidNotation" : "ukc1202-06700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc1202-06700/2017:1", "controllerName" : "Redcar and Cleveland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -919,7 +951,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-06900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/06900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-06900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-06900/2017:1", "controllerName" : "Scarborough"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/06900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -948,7 +981,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07000/2017:1", "controllerName" : "Scarborough"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -977,7 +1011,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07100/date/20160919/time/125000/recordDate/20160919", "name" : {"_value" : "Whitby", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07100/2017:1", "controllerName" : "Scarborough"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07100/date/20160919/time/125000/recordDate/20160919", "name" : {"_value" : "Whitby", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/whitby", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07100", "easting" : 489191.0, "lat" : 54.4916967106725, "long" : -0.624582898103651, "name" : {"_value" : "Sampling point at Whitby", "_lang" : "en"}
@@ -1002,7 +1037,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07200/2017:1", "controllerName" : "Scarborough"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1031,7 +1067,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07300/date/20160919/time/144500/recordDate/20160919", "name" : {"_value" : "Scarborough North Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07300/2017:1", "controllerName" : "Scarborough"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07300/date/20160919/time/144500/recordDate/20160919", "name" : {"_value" : "Scarborough North Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/scarborough-north-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07300", "easting" : 503769.0, "lat" : 54.2933647936044, "long" : -0.407208402772809, "name" : {"_value" : "Sampling point at Scarborough North Bay", "_lang" : "en"}
@@ -1056,7 +1093,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/4", "name" : {"_value" : "Poor", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07400/2017:1", "controllerName" : "Scarborough"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1085,7 +1123,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07500/date/20160919/time/153000/recordDate/20160919", "name" : {"_value" : "Cayton Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07500/2017:1", "controllerName" : "Scarborough"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07500/date/20160919/time/153000/recordDate/20160919", "name" : {"_value" : "Cayton Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/cayton-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07500", "easting" : 506775.0, "lat" : 54.2447830381406, "long" : -0.362946553116245, "name" : {"_value" : "Sampling point at Cayton Bay", "_lang" : "en"}
@@ -1110,7 +1149,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07600/date/20160919/time/160000/recordDate/20160919", "name" : {"_value" : "Filey", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07600/2017:1", "controllerName" : "Scarborough"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07600/date/20160919/time/160000/recordDate/20160919", "name" : {"_value" : "Filey", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/filey", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07600", "easting" : 512003.0, "lat" : 54.2082372558266, "long" : -0.284226456988846, "name" : {"_value" : "Sampling point at Filey", "_lang" : "en"}
@@ -1135,7 +1175,8 @@ http_interactions:
               , "eubwidNotation" : "uke2206-07700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07700/date/20160919/time/162000/recordDate/20160919", "name" : {"_value" : "Reighton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke2206-07700/2017:1", "controllerName" : "Scarborough"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07700/date/20160919/time/162000/recordDate/20160919", "name" : {"_value" : "Reighton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/reighton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07700", "easting" : 514355.0, "lat" : 54.1691179111152, "long" : -0.249814208841969, "name" : {"_value" : "Sampling point at Reighton", "_lang" : "en"}
@@ -1158,7 +1199,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-07900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-07900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-07900/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/07900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1185,7 +1227,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-07950", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/07950/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-07950/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07950/date/20160920/time/103300/recordDate/20160920", "name" : {"_value" : "Danes Dyke, Flamborough", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-07950/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/07950/date/20160920/time/103300/recordDate/20160920", "name" : {"_value" : "Danes Dyke, Flamborough", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/danes-dyke-flamborough", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/07950", "easting" : 521592.0, "lat" : 54.1040387873291, "long" : -0.141861015595605, "name" : {"_value" : "Sampling point at Danes Dyke, Flamborough", "_lang" : "en"}
@@ -1208,7 +1251,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08000/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1235,7 +1279,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08100/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1262,7 +1307,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08200/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1289,7 +1335,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08300/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/08300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1316,7 +1363,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08600/date/20160920/time/134000/recordDate/20160920", "name" : {"_value" : "Skipsea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08600/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08600/date/20160920/time/134000/recordDate/20160920", "name" : {"_value" : "Skipsea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/skipsea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/08600", "easting" : 518837.0, "lat" : 53.9619402767489, "long" : -0.190183487177237, "name" : {"_value" : "Sampling point at Skipsea", "_lang" : "en"}
@@ -1345,7 +1393,8 @@ http_interactions:
                 , "nirsRef" : "01411946", "som_recordDateTime" : {"_value" : "2017-03-24T11:08:58", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-24T10:41:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08700/date/20160920/time/141000/recordDate/20160920", "name" : {"_value" : "Hornsea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08700/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08700/date/20160920/time/141000/recordDate/20160920", "name" : {"_value" : "Hornsea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hornsea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/08700", "easting" : 520923.0, "lat" : 53.9140984449623, "long" : -0.160491171265782, "name" : {"_value" : "Sampling point at Hornsea", "_lang" : "en"}
@@ -1368,7 +1417,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08800/date/20160920/time/150000/recordDate/20160920", "name" : {"_value" : "Tunstall", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08800/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08800/date/20160920/time/150000/recordDate/20160920", "name" : {"_value" : "Tunstall", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/tunstall", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/08800", "easting" : 531800.0, "lat" : 53.7610025107837, "long" : -0.00217466531664513, "name" : {"_value" : "Sampling point at Tunstall", "_lang" : "en"}
@@ -1391,7 +1441,8 @@ http_interactions:
               , "eubwidNotation" : "uke1200-08900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/08900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08900/date/20160920/time/154500/recordDate/20160920", "name" : {"_value" : "Withernsea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1200-08900/2017:1", "controllerName" : "East Riding of Yorkshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/08900/date/20160920/time/154500/recordDate/20160920", "name" : {"_value" : "Withernsea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-east-north-east-office", "name" : {"_value" : "North East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/withernsea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/08900", "easting" : 534413.0, "lat" : 53.7308197034631, "long" : 0.0360078045744803, "name" : {"_value" : "Sampling point at Withernsea", "_lang" : "en"}
@@ -1414,7 +1465,8 @@ http_interactions:
               , "eubwidNotation" : "uke1301-09000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1301-09000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/09000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1301-09000/2017:1", "controllerName" : "North East Lincolnshire"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/09000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1441,7 +1493,8 @@ http_interactions:
               , "eubwidNotation" : "uke1301-09020", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09020/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1301-09020/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09020/date/20160926/time/143900/recordDate/20160926", "name" : {"_value" : "Humberston Fitties", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uke1301-09020/2017:1", "controllerName" : "North East Lincolnshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09020/date/20160926/time/143900/recordDate/20160926", "name" : {"_value" : "Humberston Fitties", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/humberston-fitties", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09020", "easting" : 533204.0, "lat" : 53.5351901275229, "long" : 0.008380462066923, "name" : {"_value" : "Sampling point at Humberston Fitties", "_lang" : "en"}
@@ -1466,7 +1519,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09100/date/20160926/time/125900/recordDate/20160926", "name" : {"_value" : "Mablethorpe Town", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09100/2017:1", "controllerName" : "East Lindsey"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09100/date/20160926/time/125900/recordDate/20160926", "name" : {"_value" : "Mablethorpe Town", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/mablethorpe-town", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09100", "easting" : 550842.0, "lat" : 53.3441337592485, "long" : 0.264365936524175, "name" : {"_value" : "Sampling point at Mablethorpe Town", "_lang" : "en"}
@@ -1491,7 +1545,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09200/date/20160926/time/124000/recordDate/20160926", "name" : {"_value" : "Sutton-on-Sea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09200/2017:1", "controllerName" : "East Lindsey"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09200/date/20160926/time/124000/recordDate/20160926", "name" : {"_value" : "Sutton-on-Sea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sutton-on-sea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09200", "easting" : 552242.0, "lat" : 53.3145880700532, "long" : 0.283819713023732, "name" : {"_value" : "Sampling point at Sutton-on-Sea", "_lang" : "en"}
@@ -1516,7 +1571,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09300/date/20160926/time/121500/recordDate/20160926", "name" : {"_value" : "Moggs Eye", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09300/2017:1", "controllerName" : "Lincolnshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09300/date/20160926/time/121500/recordDate/20160926", "name" : {"_value" : "Moggs Eye", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/moggs-eye", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09300", "easting" : 554698.0, "lat" : 53.273002875866, "long" : 0.318438394444607, "name" : {"_value" : "Sampling point at Moggs Eye", "_lang" : "en"}
@@ -1541,7 +1597,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09400/date/20160926/time/115000/recordDate/20160926", "name" : {"_value" : "Anderby", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09400/2017:1", "controllerName" : "Lincolnshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09400/date/20160926/time/115000/recordDate/20160926", "name" : {"_value" : "Anderby", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/anderby", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09400", "easting" : 555218.0, "lat" : 53.2597742443608, "long" : 0.325519540952037, "name" : {"_value" : "Sampling point at Anderby", "_lang" : "en"}
@@ -1566,7 +1623,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09500/date/20160926/time/112500/recordDate/20160926", "name" : {"_value" : "Chapel St Leonards", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09500/2017:1", "controllerName" : "Chapel St. Leonards"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09500/date/20160926/time/112500/recordDate/20160926", "name" : {"_value" : "Chapel St Leonards", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/chapel-st-leonards", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09500", "easting" : 556313.0, "lat" : 53.2236446994753, "long" : 0.339965691745724, "name" : {"_value" : "Sampling point at Chapel St Leonards", "_lang" : "en"}
@@ -1591,7 +1649,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09600/date/20160926/time/105500/recordDate/20160926", "name" : {"_value" : "Ingoldmells South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09600/2017:1", "controllerName" : "East Lindsey"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09600/date/20160926/time/105500/recordDate/20160926", "name" : {"_value" : "Ingoldmells South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ingoldmells-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09600", "easting" : 557458.0, "lat" : 53.1877411825559, "long" : 0.355149330426732, "name" : {"_value" : "Sampling point at Ingoldmells South", "_lang" : "en"}
@@ -1616,7 +1675,8 @@ http_interactions:
               , "eubwidNotation" : "ukf3102-09700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09700/date/20160926/time/102500/recordDate/20160926", "name" : {"_value" : "Skegness", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf3102-09700/2017:1", "controllerName" : "East Lindsey"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09700/date/20160926/time/102500/recordDate/20160926", "name" : {"_value" : "Skegness", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/skegness", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09700", "easting" : 557243.0, "lat" : 53.1441464100115, "long" : 0.349547789114293, "name" : {"_value" : "Sampling point at Skegness", "_lang" : "en"}
@@ -1639,7 +1699,8 @@ http_interactions:
               , "eubwidNotation" : "ukf1400-09750", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09750/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf1400-09750/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09750/date/20160920/time/144000/recordDate/20160920", "name" : {"_value" : "Colwick Country Park (West Lake)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukf1400-09750/2017:1", "controllerName" : "City of Nottingham"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09750/date/20160920/time/144000/recordDate/20160920", "name" : {"_value" : "Colwick Country Park (West Lake)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/midlands-midlands-office", "name" : {"_value" : "Midlands", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/colwick-country-park-west-lake", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09750", "easting" : 460698.0, "lat" : 52.9451435484652, "long" : -1.09815737913614, "name" : {"_value" : "Sampling point at Colwick Country Park (West Lake)", "_lang" : "en"}
@@ -1664,7 +1725,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1304-09800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/09800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09800/2017:1", "controllerName" : "King's Lynn and West Norfolk"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/09800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1693,7 +1755,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1304-09850", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09850/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09850/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09850/date/20160926/time/145000/recordDate/20160926", "name" : {"_value" : "Hunstanton Main Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09850/2017:1", "controllerName" : "King's Lynn and West Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09850/date/20160926/time/145000/recordDate/20160926", "name" : {"_value" : "Hunstanton Main Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hunstanton-main-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09850", "easting" : 567020.0, "lat" : 52.936821736507, "long" : 0.483787390916709, "name" : {"_value" : "Sampling point at Hunstanton Main Beach", "_lang" : "en"}
@@ -1718,7 +1781,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1304-09900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/09900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09900/date/20160926/time/142500/recordDate/20160926", "name" : {"_value" : "Hunstanton (Old Hunstanton)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1304-09900/2017:1", "controllerName" : "King's Lynn and West Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/09900/date/20160926/time/142500/recordDate/20160926", "name" : {"_value" : "Hunstanton (Old Hunstanton)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hunstanton-old-hunstanton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/09900", "easting" : 567800.0, "lat" : 52.953642084641, "long" : 0.496364280806723, "name" : {"_value" : "Sampling point at Hunstanton (Old Hunstanton)", "_lang" : "en"}
@@ -1743,7 +1807,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10000/date/20160925/time/101200/recordDate/20160925", "name" : {"_value" : "Wells", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10000/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10000/date/20160925/time/101200/recordDate/20160925", "name" : {"_value" : "Wells", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/wells", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10000", "easting" : 591400.0, "lat" : 52.973582594339, "long" : 0.849053394593845, "name" : {"_value" : "Sampling point at Wells", "_lang" : "en"}
@@ -1768,7 +1833,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10100/date/20160925/time/110200/recordDate/20160925", "name" : {"_value" : "Sheringham", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10100/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10100/date/20160925/time/110200/recordDate/20160925", "name" : {"_value" : "Sheringham", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sheringham", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10100", "easting" : 615665.0, "lat" : 52.9459370506713, "long" : 1.20848053319422, "name" : {"_value" : "Sampling point at Sheringham", "_lang" : "en"}
@@ -1793,7 +1859,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10125", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10125/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10125/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10125/date/20160925/time/114200/recordDate/20160925", "name" : {"_value" : "West Runton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10125/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10125/date/20160925/time/114200/recordDate/20160925", "name" : {"_value" : "West Runton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-runton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10125", "easting" : 618660.0, "lat" : 52.9416822075366, "long" : 1.25276663199985, "name" : {"_value" : "Sampling point at West Runton", "_lang" : "en"}
@@ -1818,7 +1885,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10150", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10150/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10150/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10150/date/20160925/time/115900/recordDate/20160925", "name" : {"_value" : "East Runton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10150/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10150/date/20160925/time/115900/recordDate/20160925", "name" : {"_value" : "East Runton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/east-runton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10150", "easting" : 620242.0, "lat" : 52.9370619292274, "long" : 1.27595332448127, "name" : {"_value" : "Sampling point at East Runton", "_lang" : "en"}
@@ -1843,7 +1911,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10200/date/20160925/time/121500/recordDate/20160925", "name" : {"_value" : "Cromer", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10200/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10200/date/20160925/time/121500/recordDate/20160925", "name" : {"_value" : "Cromer", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/cromer", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10200", "easting" : 622025.0, "lat" : 52.9325124160506, "long" : 1.30216261138879, "name" : {"_value" : "Sampling point at Cromer", "_lang" : "en"}
@@ -1868,7 +1937,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10300/date/20160925/time/124000/recordDate/20160925", "name" : {"_value" : "Mundesley", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10300/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10300/date/20160925/time/124000/recordDate/20160925", "name" : {"_value" : "Mundesley", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/mundesley", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10300", "easting" : 631700.0, "lat" : 52.8769429465284, "long" : 1.44174118339281, "name" : {"_value" : "Sampling point at Mundesley", "_lang" : "en"}
@@ -1893,7 +1963,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1305-10310", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10310/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10310/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10310/date/20160925/time/131500/recordDate/20160925", "name" : {"_value" : "Sea Palling", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1305-10310/2017:1", "controllerName" : "North Norfolk"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10310/date/20160925/time/131500/recordDate/20160925", "name" : {"_value" : "Sea Palling", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sea-palling", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10310", "easting" : 643090.0, "lat" : 52.7906397541907, "long" : 1.60390398189731, "name" : {"_value" : "Sampling point at Sea Palling", "_lang" : "en"}
@@ -1918,7 +1989,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10325", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10325/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10325/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10325/date/20160925/time/134100/recordDate/20160925", "name" : {"_value" : "Hemsby", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10325/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10325/date/20160925/time/134100/recordDate/20160925", "name" : {"_value" : "Hemsby", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hemsby", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10325", "easting" : 650793.0, "lat" : 52.6952681733587, "long" : 1.71007376962362, "name" : {"_value" : "Sampling point at Hemsby", "_lang" : "en"}
@@ -1943,7 +2015,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10350/date/20160925/time/140300/recordDate/20160925", "name" : {"_value" : "Caister Point", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10350/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10350/date/20160925/time/140300/recordDate/20160925", "name" : {"_value" : "Caister Point", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/caister-point", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10350", "easting" : 652922.0, "lat" : 52.6462329700534, "long" : 1.73740119135091, "name" : {"_value" : "Sampling point at Caister Point", "_lang" : "en"}
@@ -1968,7 +2041,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/10400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10400/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/10400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -1997,7 +2071,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10500/date/20160925/time/152500/recordDate/20160925", "name" : {"_value" : "Great Yarmouth Pier", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10500/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10500/date/20160925/time/152500/recordDate/20160925", "name" : {"_value" : "Great Yarmouth Pier", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/great-yarmouth-pier", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10500", "easting" : 653300.0, "lat" : 52.6052855908066, "long" : 1.73949475736344, "name" : {"_value" : "Sampling point at Great Yarmouth Pier", "_lang" : "en"}
@@ -2022,7 +2097,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10600/date/20160925/time/151000/recordDate/20160925", "name" : {"_value" : "Great Yarmouth South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10600/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10600/date/20160925/time/151000/recordDate/20160925", "name" : {"_value" : "Great Yarmouth South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/great-yarmouth-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10600", "easting" : 653300.0, "lat" : 52.5963149719545, "long" : 1.73872991605364, "name" : {"_value" : "Sampling point at Great Yarmouth South", "_lang" : "en"}
@@ -2047,7 +2123,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1303-10650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10650/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10650/date/20160925/time/142000/recordDate/20160925", "name" : {"_value" : "Gorleston Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1303-10650/2017:1", "controllerName" : "Great Yarmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10650/date/20160925/time/142000/recordDate/20160925", "name" : {"_value" : "Gorleston Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/gorleston-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10650", "easting" : 653096.0, "lat" : 52.5697918425, "long" : 1.73347417364, "name" : {"_value" : "Sampling point at Gorleston Beach", "_lang" : "en"}
@@ -2083,7 +2160,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-03-31T11:23:58", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-31T11:22:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10750/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10750/date/20160925/time/131000/recordDate/20160925", "name" : {"_value" : "Lowestoft (North of Claremont Pier)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10750/2017:1", "controllerName" : "Waveney"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10750/date/20160925/time/131000/recordDate/20160925", "name" : {"_value" : "Lowestoft (North of Claremont Pier)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/lowestoft-north-of-claremont-pier", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10750", "easting" : 654718.0, "lat" : 52.4683066878659, "long" : 1.74874459923372, "name" : {"_value" : "Sampling point at Lowestoft (North of Claremont Pier)", "_lang" : "en"}
@@ -2108,7 +2186,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1407-10800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10800/date/20160925/time/132500/recordDate/20160925", "name" : {"_value" : "Lowestoft (South of Claremont Pier)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10800/2017:1", "controllerName" : "Waveney"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10800/date/20160925/time/132500/recordDate/20160925", "name" : {"_value" : "Lowestoft (South of Claremont Pier)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/lowestoft-south-of-claremont-pier", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10800", "easting" : 654500.0, "lat" : 52.4638869856628, "long" : 1.74515820945775, "name" : {"_value" : "Sampling point at Lowestoft (South of Claremont Pier)", "_lang" : "en"}
@@ -2133,7 +2212,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1407-10830", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10830/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10830/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10830/date/20160925/time/113500/recordDate/20160925", "name" : {"_value" : "Southwold The Pier", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10830/2017:1", "controllerName" : "Waveney"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10830/date/20160925/time/113500/recordDate/20160925", "name" : {"_value" : "Southwold The Pier", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/southwold-the-pier", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10830", "easting" : 651300.0, "lat" : 52.3307965572847, "long" : 1.68690961295553, "name" : {"_value" : "Sampling point at Southwold The Pier", "_lang" : "en"}
@@ -2158,7 +2238,8 @@ http_interactions:
               , "eubwidNotation" : "ukh1407-10850", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/10850/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10850/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10850/date/20160925/time/120000/recordDate/20160925", "name" : {"_value" : "Southwold The Denes", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1407-10850/2017:1", "controllerName" : "Waveney"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10850/date/20160925/time/120000/recordDate/20160925", "name" : {"_value" : "Southwold The Denes", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/southwold-the-denes", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10850", "easting" : 650800.0, "lat" : 52.3193619673795, "long" : 1.67861883167939, "name" : {"_value" : "Sampling point at Southwold The Denes", "_lang" : "en"}
@@ -2189,7 +2270,8 @@ http_interactions:
                 , "nirsRef" : "99988877", "som_recordDateTime" : {"_value" : "2017-03-31T11:18:58", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-31T11:16:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1406-10900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10900/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "Felixstowe North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1406-10900/2017:1", "controllerName" : "Suffolk Coastal"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/10900/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "Felixstowe North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/felixstowe-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/10900", "easting" : 630598.0, "lat" : 51.9603405905382, "long" : 1.35498582937495, "name" : {"_value" : "Sampling point at Felixstowe North", "_lang" : "en"}
@@ -2220,7 +2302,8 @@ http_interactions:
                 , "nirsRef" : "99988877", "som_recordDateTime" : {"_value" : "2017-03-31T11:18:58", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-31T11:16:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1406-11000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11000/date/20160925/time/101500/recordDate/20160925", "name" : {"_value" : "Felixstowe South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh1406-11000/2017:1", "controllerName" : "Suffolk Coastal"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11000/date/20160925/time/101500/recordDate/20160925", "name" : {"_value" : "Felixstowe South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/felixstowe-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11000", "easting" : 629700.0, "lat" : 51.9543304067933, "long" : 1.34146436108153, "name" : {"_value" : "Sampling point at Felixstowe South", "_lang" : "en"}
@@ -2245,7 +2328,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11100/date/20160925/time/152200/recordDate/20160925", "name" : {"_value" : "Dovercourt", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11100/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11100/date/20160925/time/152200/recordDate/20160925", "name" : {"_value" : "Dovercourt", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/dovercourt", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11100", "easting" : 625170.0, "lat" : 51.9287145174992, "long" : 1.27365363707728, "name" : {"_value" : "Sampling point at Dovercourt", "_lang" : "en"}
@@ -2270,7 +2354,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11250", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11250/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11250/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11250/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11250/2017:1", "controllerName" : "Tendring"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11250/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2299,7 +2384,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11300/date/20160925/time/142800/recordDate/20160925", "name" : {"_value" : "Frinton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11300/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11300/date/20160925/time/142800/recordDate/20160925", "name" : {"_value" : "Frinton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/frinton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11300", "easting" : 623928.0, "lat" : 51.8277889573572, "long" : 1.24830941766983, "name" : {"_value" : "Sampling point at Frinton", "_lang" : "en"}
@@ -2324,7 +2410,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11350/date/20160925/time/134400/recordDate/20160925", "name" : {"_value" : "Holland", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11350/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11350/date/20160925/time/134400/recordDate/20160925", "name" : {"_value" : "Holland", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/holland", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11350", "easting" : 622450.0, "lat" : 51.8132012147031, "long" : 1.22579854706484, "name" : {"_value" : "Sampling point at Holland", "_lang" : "en"}
@@ -2349,7 +2436,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11500/date/20160925/time/132000/recordDate/20160925", "name" : {"_value" : "Clacton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11500/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11500/date/20160925/time/132000/recordDate/20160925", "name" : {"_value" : "Clacton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/clacton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11500", "easting" : 618790.0, "lat" : 51.7930992766385, "long" : 1.17127582820326, "name" : {"_value" : "Sampling point at Clacton", "_lang" : "en"}
@@ -2374,7 +2462,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11550", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11550/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/4", "name" : {"_value" : "Poor", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11550/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11550/date/20160925/time/120800/recordDate/20160925", "name" : {"_value" : "Clacton (Groyne 41)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11550/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11550/date/20160925/time/120800/recordDate/20160925", "name" : {"_value" : "Clacton (Groyne 41)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/clacton-groyne-41", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11550", "easting" : 617600.0, "lat" : 51.785, "long" : 1.1535, "name" : {"_value" : "Sampling point at Clacton (Groyne 41)", "_lang" : "en"}
@@ -2399,7 +2488,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11600/date/20160925/time/111000/recordDate/20160925", "name" : {"_value" : "Jaywick", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11600/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11600/date/20160925/time/111000/recordDate/20160925", "name" : {"_value" : "Jaywick", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/jaywick", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11600", "easting" : 614850.0, "lat" : 51.772629737974, "long" : 1.1127180240145, "name" : {"_value" : "Sampling point at Jaywick", "_lang" : "en"}
@@ -2424,7 +2514,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11650/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11650/date/20160925/time/113300/recordDate/20160925", "name" : {"_value" : "Clacton Beach Martello Tower", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11650/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11650/date/20160925/time/113300/recordDate/20160925", "name" : {"_value" : "Clacton Beach Martello Tower", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/clacton-beach-martello-tower", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11650", "easting" : 616700.0, "lat" : 51.7799970257233, "long" : 1.14005075867046, "name" : {"_value" : "Sampling point at Clacton Beach Martello Tower", "_lang" : "en"}
@@ -2449,7 +2540,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3311-11700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11700/date/20160925/time/104000/recordDate/20160925", "name" : {"_value" : "Brightlingsea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3311-11700/2017:1", "controllerName" : "Tendring"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11700/date/20160925/time/104000/recordDate/20160925", "name" : {"_value" : "Brightlingsea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/brightlingsea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11700", "easting" : 607647.0, "lat" : 51.8057114363672, "long" : 1.01049496166788, "name" : {"_value" : "Sampling point at Brightlingsea", "_lang" : "en"}
@@ -2474,7 +2566,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3306-11750", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11750/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3306-11750/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11750/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "West Mersea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3306-11750/2017:1", "controllerName" : "Colchester"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11750/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "West Mersea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/anglian-anglian-office-anglian-office", "name" : {"_value" : "Anglian", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-mersea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11750", "easting" : 602270.0, "lat" : 51.7703990868537, "long" : 0.930194910705001, "name" : {"_value" : "Sampling point at West Mersea", "_lang" : "en"}
@@ -2499,7 +2592,8 @@ http_interactions:
               , "eubwidNotation" : "ukk1302-11760", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11760/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1302-11760/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11760/date/20160920/time/111500/recordDate/20160920", "name" : {"_value" : "Cotswold Country Park and Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1302-11760/2017:1", "controllerName" : "Cotswold"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11760/date/20160920/time/111500/recordDate/20160920", "name" : {"_value" : "Cotswold Country Park and Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/cotswold-country-park-and-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11760", "easting" : 402800.0, "lat" : 51.6609853223097, "long" : -1.96093036014707, "name" : {"_value" : "Sampling point at Cotswold Country Park and Beach", "_lang" : "en"}
@@ -2522,7 +2616,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11770", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11770/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11770/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11770/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11770/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11770/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2549,7 +2644,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11780", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11780/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11780/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11780/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11780/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11780/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2576,7 +2672,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11800/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2603,7 +2700,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11830", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11830/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11830/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11830/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11830/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11830/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2630,7 +2728,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11850", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11850/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11850/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11850/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11850/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11850/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2657,7 +2756,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11900/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2684,7 +2784,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11902", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11902/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11902/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11902/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11902/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11902/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2711,7 +2812,8 @@ http_interactions:
               , "eubwidNotation" : "ukh3100-11904", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11904/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11904/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11904/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukh3100-11904/2017:1", "controllerName" : "Southend-on-Sea"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11904/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2740,7 +2842,8 @@ http_interactions:
               , "eubwidNotation" : "uki1101-11910", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11910/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11910/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11910/date/20160919/time/134300/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Ladies Pond)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11910/2017:1", "controllerName" : "City and County of the City of London"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11910/date/20160919/time/134300/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Ladies Pond)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hampstead-heath-ladies-pond", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11910", "easting" : 527620.0, "lat" : 51.5667313295976, "long" : -0.160132015758681, "name" : {"_value" : "Sampling point at Hampstead Heath (Ladies Pond)", "_lang" : "en"}
@@ -2765,7 +2868,8 @@ http_interactions:
               , "eubwidNotation" : "uki1101-11920", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11920/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11920/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11920/date/20160919/time/131900/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Mens Pond)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11920/2017:1", "controllerName" : "City and County of the City of London"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11920/date/20160919/time/131900/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Mens Pond)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hampstead-heath-mens-pond", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11920", "easting" : 527870.0, "lat" : 51.5633496709908, "long" : -0.156661551621384, "name" : {"_value" : "Sampling point at Hampstead Heath (Mens Pond)", "_lang" : "en"}
@@ -2790,7 +2894,8 @@ http_interactions:
               , "eubwidNotation" : "uki1101-11930", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11930/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11930/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11930/date/20160919/time/142400/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Mixed Pond)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1101-11930/2017:1", "controllerName" : "City and County of the City of London"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11930/date/20160919/time/142400/recordDate/20160919", "name" : {"_value" : "Hampstead Heath (Mixed Pond)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hampstead-heath-mixed-pond", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11930", "easting" : 527210.0, "lat" : 51.5607128839653, "long" : -0.166289996763097, "name" : {"_value" : "Sampling point at Hampstead Heath (Mixed Pond)", "_lang" : "en"}
@@ -2815,7 +2920,8 @@ http_interactions:
               , "eubwidNotation" : "uki1106-11940", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11940/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1106-11940/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11940/date/20160919/time/152800/recordDate/20160919", "name" : {"_value" : "The Serpentine - Hyde Park", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/uki1106-11940/2017:1", "controllerName" : "City of Westminster"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11940/date/20160919/time/152800/recordDate/20160919", "name" : {"_value" : "The Serpentine - Hyde Park", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/the-serpentine-hyde-park", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11940", "easting" : 527170.0, "lat" : 51.5049137923283, "long" : -0.169107214526447, "name" : {"_value" : "Sampling point at The Serpentine - Hyde Park", "_lang" : "en"}
@@ -2840,7 +2946,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2310-11945", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11945/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2310-11945/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11945/date/20160919/time/160000/recordDate/20160919", "name" : {"_value" : "Frensham Great Pond", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2310-11945/2017:1", "controllerName" : "Waverley"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11945/date/20160919/time/160000/recordDate/20160919", "name" : {"_value" : "Frensham Great Pond", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/frensham-great-pond", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11945", "easting" : 484588.0, "lat" : 51.1573227078271, "long" : -0.791833579836205, "name" : {"_value" : "Sampling point at Frensham Great Pond", "_lang" : "en"}
@@ -2865,7 +2972,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4209-11950", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11950/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-11950/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11950/date/20160913/time/102200/recordDate/20160913", "name" : {"_value" : "Sheerness", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-11950/2017:1", "controllerName" : "Swale"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/11950/date/20160913/time/102200/recordDate/20160913", "name" : {"_value" : "Sheerness", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sheerness", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/11950", "easting" : 591917.0, "lat" : 51.4432594353138, "long" : 0.760205649449072, "name" : {"_value" : "Sampling point at Sheerness", "_lang" : "en"}
@@ -2890,7 +2998,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4209-11975", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/11975/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-11975/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11975/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-11975/2017:1", "controllerName" : "Swale"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/11975/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2919,7 +3028,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4209-12000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-12000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4209-12000/2017:1", "controllerName" : "Swale"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -2948,7 +3058,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4202-12100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12100/date/20160913/time/122000/recordDate/20160913", "name" : {"_value" : "West Beach, Whitstable", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12100/2017:1", "controllerName" : "Canterbury"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12100/date/20160913/time/122000/recordDate/20160913", "name" : {"_value" : "West Beach, Whitstable", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-beach-whitstable", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12100", "easting" : 609800.0, "lat" : 51.3543349703393, "long" : 1.01172153066364, "name" : {"_value" : "Sampling point at West Beach, Whitstable", "_lang" : "en"}
@@ -2973,7 +3084,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4202-12120", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12120/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12120/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12120/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12120/2017:1", "controllerName" : "Canterbury"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12120/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3002,7 +3114,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4202-12150", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12150/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12150/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12150/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12150/2017:1", "controllerName" : "Canterbury"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12150/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3031,7 +3144,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4202-12200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4202-12200/2017:1", "controllerName" : "Canterbury"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3060,7 +3174,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12300/date/20160913/time/134600/recordDate/20160913", "name" : {"_value" : "Minnis Bay, Birchington", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12300/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12300/date/20160913/time/134600/recordDate/20160913", "name" : {"_value" : "Minnis Bay, Birchington", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/minnis-bay-birchington", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12300", "easting" : 628600.0, "lat" : 51.3803038326327, "long" : 1.28364552660244, "name" : {"_value" : "Sampling point at Minnis Bay, Birchington", "_lang" : "en"}
@@ -3085,7 +3200,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12350/date/20160913/time/141000/recordDate/20160913", "name" : {"_value" : "West Bay, Westgate", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12350/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12350/date/20160913/time/141000/recordDate/20160913", "name" : {"_value" : "West Bay, Westgate", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-bay-westgate", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12350", "easting" : 631968.0, "lat" : 51.3832025571345, "long" : 1.33226728524173, "name" : {"_value" : "Sampling point at West Bay, Westgate", "_lang" : "en"}
@@ -3110,7 +3226,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12400/date/20160913/time/141000/recordDate/20160913", "name" : {"_value" : "St Mildred's Bay, Westgate", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12400/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12400/date/20160913/time/141000/recordDate/20160913", "name" : {"_value" : "St Mildred's Bay, Westgate", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/st-mildreds-bay-westgate", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12400", "easting" : 632687.0, "lat" : 51.3848922879526, "long" : 1.34272601331783, "name" : {"_value" : "Sampling point at St Mildred's Bay, Westgate", "_lang" : "en"}
@@ -3135,7 +3252,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12450", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12450/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12450/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12450/date/20160920/time/155200/recordDate/20160920", "name" : {"_value" : "Westbrook Bay, Margate", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12450/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12450/date/20160920/time/155200/recordDate/20160920", "name" : {"_value" : "Westbrook Bay, Margate", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/westbrook-bay-margate", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12450", "easting" : 634100.0, "lat" : 51.3861428860402, "long" : 1.36313023717547, "name" : {"_value" : "Sampling point at Westbrook Bay, Margate", "_lang" : "en"}
@@ -3160,7 +3278,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12500/date/20160920/time/153800/recordDate/20160920", "name" : {"_value" : "Margate The Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12500/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12500/date/20160920/time/153800/recordDate/20160920", "name" : {"_value" : "Margate The Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/margate-the-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12500", "easting" : 634970.0, "lat" : 51.3877045480062, "long" : 1.37575225993371, "name" : {"_value" : "Sampling point at Margate The Bay", "_lang" : "en"}
@@ -3185,7 +3304,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12600/date/20160920/time/152400/recordDate/20160920", "name" : {"_value" : "Margate Fulsam Rock", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12600/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12600/date/20160920/time/152400/recordDate/20160920", "name" : {"_value" : "Margate Fulsam Rock", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/margate-fulsam-rock", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12600", "easting" : 635692.0, "lat" : 51.3926832590616, "long" : 1.38649991630989, "name" : {"_value" : "Sampling point at Margate Fulsam Rock", "_lang" : "en"}
@@ -3210,7 +3330,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12630", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12630/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/4", "name" : {"_value" : "Poor", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12630/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12630/date/20160921/time/163600/recordDate/20160921", "name" : {"_value" : "Walpole Bay, Margate", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12630/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12630/date/20160921/time/163600/recordDate/20160921", "name" : {"_value" : "Walpole Bay, Margate", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/walpole-bay-margate", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12630", "easting" : 636570.0, "lat" : 51.3922553681592, "long" : 1.39909205384006, "name" : {"_value" : "Sampling point at Walpole Bay, Margate", "_lang" : "en"}
@@ -3235,7 +3356,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12660", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12660/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12660/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12660/date/20160920/time/143500/recordDate/20160920", "name" : {"_value" : "Botany Bay, Broadstairs", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12660/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12660/date/20160920/time/143500/recordDate/20160920", "name" : {"_value" : "Botany Bay, Broadstairs", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/botany-bay-broadstairs", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12660", "easting" : 639100.0, "lat" : 51.3894456556124, "long" : 1.43525760038043, "name" : {"_value" : "Sampling point at Botany Bay, Broadstairs", "_lang" : "en"}
@@ -3260,7 +3382,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12700/date/20160920/time/141600/recordDate/20160920", "name" : {"_value" : "Joss Bay, Broadstairs", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12700/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12700/date/20160920/time/141600/recordDate/20160920", "name" : {"_value" : "Joss Bay, Broadstairs", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/joss-bay-broadstairs", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12700", "easting" : 639908.0, "lat" : 51.3792230675941, "long" : 1.44610563272459, "name" : {"_value" : "Sampling point at Joss Bay, Broadstairs", "_lang" : "en"}
@@ -3285,7 +3408,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12750", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12750/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12750/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12750/date/20160920/time/113500/recordDate/20160920", "name" : {"_value" : "Broadstairs, Stone Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12750/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12750/date/20160920/time/113500/recordDate/20160920", "name" : {"_value" : "Broadstairs, Stone Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/broadstairs-stone-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12750", "easting" : 639923.0, "lat" : 51.3654395136107, "long" : 1.44528543183743, "name" : {"_value" : "Sampling point at Broadstairs, Stone Bay", "_lang" : "en"}
@@ -3310,7 +3434,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12800/2017:1", "controllerName" : "Thanet"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3339,7 +3464,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12850", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12850/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12850/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12850/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12850/2017:1", "controllerName" : "Thanet"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/12850/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3368,7 +3494,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4210-12900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/12900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12900/date/20160920/time/131000/recordDate/20160920", "name" : {"_value" : "Ramsgate Western Undercliffe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4210-12900/2017:1", "controllerName" : "Thanet"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/12900/date/20160920/time/131000/recordDate/20160920", "name" : {"_value" : "Ramsgate Western Undercliffe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ramsgate-western-undercliffe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/12900", "easting" : 637406.0, "lat" : 51.32660788452, "long" : 1.40623423433956, "name" : {"_value" : "Sampling point at Ramsgate Western Undercliffe", "_lang" : "en"}
@@ -3393,7 +3520,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4204-13000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13000/date/20160920/time/123000/recordDate/20160920", "name" : {"_value" : "Sandwich Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13000/2017:1", "controllerName" : "Dover"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13000/date/20160920/time/123000/recordDate/20160920", "name" : {"_value" : "Sandwich Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sandwich-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13000", "easting" : 635778.0, "lat" : 51.2826015238971, "long" : 1.37962358666148, "name" : {"_value" : "Sampling point at Sandwich Bay", "_lang" : "en"}
@@ -3418,7 +3546,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4204-13100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13100/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Deal Castle", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13100/2017:1", "controllerName" : "Dover"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13100/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Deal Castle", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/deal-castle", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13100", "easting" : 637837.0, "lat" : 51.2248658248295, "long" : 1.40488530923027, "name" : {"_value" : "Sampling point at Deal Castle", "_lang" : "en"}
@@ -3443,7 +3572,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4204-13200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13200/date/20160920/time/112100/recordDate/20160920", "name" : {"_value" : "St Margaret`s Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4204-13200/2017:1", "controllerName" : "Dover"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13200/date/20160920/time/112100/recordDate/20160920", "name" : {"_value" : "St Margaret`s Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/st-margarets-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13200", "easting" : 636878.0, "lat" : 51.1506270756334, "long" : 1.38569756652105, "name" : {"_value" : "Sampling point at St Margaret`s Bay", "_lang" : "en"}
@@ -3468,7 +3598,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13300/2017:1", "controllerName" : "Shepway"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3497,7 +3628,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13400/date/20160920/time/124100/recordDate/20160920", "name" : {"_value" : "Sandgate", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13400/2017:1", "controllerName" : "Shepway"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13400/date/20160920/time/124100/recordDate/20160920", "name" : {"_value" : "Sandgate", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sandgate", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13400", "easting" : 618800.0, "lat" : 51.07081526473, "long" : 1.12175922624862, "name" : {"_value" : "Sampling point at Sandgate", "_lang" : "en"}
@@ -3522,7 +3654,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13500/date/20160920/time/125600/recordDate/20160920", "name" : {"_value" : "Hythe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13500/2017:1", "controllerName" : "Shepway"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13500/date/20160920/time/125600/recordDate/20160920", "name" : {"_value" : "Hythe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hythe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13500", "easting" : 616000.0, "lat" : 51.0646916927223, "long" : 1.08137696303459, "name" : {"_value" : "Sampling point at Hythe", "_lang" : "en"}
@@ -3547,7 +3680,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13600/date/20160920/time/131800/recordDate/20160920", "name" : {"_value" : "Dymchurch", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13600/2017:1", "controllerName" : "Shepway"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/13600/date/20160920/time/131800/recordDate/20160920", "name" : {"_value" : "Dymchurch", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/dymchurch", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/13600", "easting" : 610240.0, "lat" : 51.0246230758988, "long" : 0.996565672336776, "name" : {"_value" : "Sampling point at Dymchurch", "_lang" : "en"}
@@ -3572,7 +3706,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13700/2017:1", "controllerName" : "Shepway"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3601,7 +3736,8 @@ http_interactions:
               , "eubwidNotation" : "ukj4208-13800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj4208-13800/2017:1", "controllerName" : "Shepway"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3630,7 +3766,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2204-13900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/13900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2204-13900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13900/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2204-13900/2017:1", "controllerName" : "Rother"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/13900/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3659,7 +3796,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2204-14000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2204-14000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14000/date/20160920/time/153300/recordDate/20160920", "name" : {"_value" : "Winchelsea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2204-14000/2017:1", "controllerName" : "Rother"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14000/date/20160920/time/153300/recordDate/20160920", "name" : {"_value" : "Winchelsea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/winchelsea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14000", "easting" : 591200.0, "lat" : 50.9064145037592, "long" : 0.718105662124692, "name" : {"_value" : "Sampling point at Winchelsea", "_lang" : "en"}
@@ -3684,7 +3822,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2202-14100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2202-14100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2202-14100/2017:1", "controllerName" : "Hastings"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3713,7 +3852,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2202-14150", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14150/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2202-14150/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14150/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2202-14150/2017:1", "controllerName" : "Hastings"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14150/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3742,7 +3882,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2205-14200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2205-14200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2205-14200/2017:1", "controllerName" : "Rother"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3771,7 +3912,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2205-14300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2205-14300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14300/date/20160921/time/125600/recordDate/20160921", "name" : {"_value" : "Norman`s Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2205-14300/2017:1", "controllerName" : "Rother"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14300/date/20160921/time/125600/recordDate/20160921", "name" : {"_value" : "Norman`s Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/normans-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14300", "easting" : 568200.0, "lat" : 50.8228241604064, "long" : 0.386655849632203, "name" : {"_value" : "Sampling point at Norman`s Bay", "_lang" : "en"}
@@ -3796,7 +3938,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2201-14400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14400/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14400/2017:1", "controllerName" : "Wealden"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/14400/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -3825,7 +3968,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2201-14500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14500/date/20160921/time/150500/recordDate/20160921", "name" : {"_value" : "Eastbourne", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14500/2017:1", "controllerName" : "Eastbourne"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14500/date/20160921/time/150500/recordDate/20160921", "name" : {"_value" : "Eastbourne", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/eastbourne", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14500", "easting" : 561400.0, "lat" : 50.7609618329818, "long" : 0.287079793834733, "name" : {"_value" : "Sampling point at Eastbourne", "_lang" : "en"}
@@ -3850,7 +3994,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2201-14550", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14550/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14550/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14550/date/20160921/time/152600/recordDate/20160921", "name" : {"_value" : "Birling Gap", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2201-14550/2017:1", "controllerName" : "Wealden"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14550/date/20160921/time/152600/recordDate/20160921", "name" : {"_value" : "Birling Gap", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/birling-gap", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14550", "easting" : 555367.0, "lat" : 50.7425953434466, "long" : 0.200669020232404, "name" : {"_value" : "Sampling point at Birling Gap", "_lang" : "en"}
@@ -3875,7 +4020,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2203-14600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2203-14600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14600/date/20160921/time/155500/recordDate/20160921", "name" : {"_value" : "Seaford", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2203-14600/2017:1", "controllerName" : "Lewes"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14600/date/20160921/time/155500/recordDate/20160921", "name" : {"_value" : "Seaford", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/seaford", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14600", "easting" : 547820.0, "lat" : 50.7713170807392, "long" : 0.0949765065444564, "name" : {"_value" : "Sampling point at Seaford", "_lang" : "en"}
@@ -3898,7 +4044,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2100-14800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14800/date/20160922/time/110000/recordDate/20160922", "name" : {"_value" : "Saltdean", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14800/2017:1", "controllerName" : "The City of Brighton and Hove"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14800/date/20160922/time/110000/recordDate/20160922", "name" : {"_value" : "Saltdean", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/saltdean", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14800", "easting" : 538100.0, "lat" : 50.7993243694268, "long" : -0.0417118106859044, "name" : {"_value" : "Sampling point at Saltdean", "_lang" : "en"}
@@ -3921,7 +4068,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2100-14900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14900/date/20160922/time/114900/recordDate/20160922", "name" : {"_value" : "Brighton Kemptown", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14900/2017:1", "controllerName" : "The City of Brighton and Hove"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14900/date/20160922/time/114900/recordDate/20160922", "name" : {"_value" : "Brighton Kemptown", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/brighton-kemptown", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14900", "easting" : 532384.0, "lat" : 50.8159631965402, "long" : -0.122161894870468, "name" : {"_value" : "Sampling point at Brighton Kemptown", "_lang" : "en"}
@@ -3944,7 +4092,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2100-14950", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/14950/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14950/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14950/date/20160922/time/121600/recordDate/20160922", "name" : {"_value" : "Brighton Central", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-14950/2017:1", "controllerName" : "The City of Brighton and Hove"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/14950/date/20160922/time/121600/recordDate/20160922", "name" : {"_value" : "Brighton Central", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/brighton-central", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/14950", "easting" : 530701.0, "lat" : 50.8202727622679, "long" : -0.145883429349536, "name" : {"_value" : "Sampling point at Brighton Central", "_lang" : "en"}
@@ -3967,7 +4116,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2100-15000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-15000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15000/date/20160922/time/123000/recordDate/20160922", "name" : {"_value" : "Hove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2100-15000/2017:1", "controllerName" : "The City of Brighton and Hove"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15000/date/20160922/time/123000/recordDate/20160922", "name" : {"_value" : "Hove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15000", "easting" : 529225.0, "lat" : 50.8232281803046, "long" : -0.16672315444046, "name" : {"_value" : "Sampling point at Hove", "_lang" : "en"}
@@ -3992,7 +4142,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2401-15100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15100/date/20160922/time/125000/recordDate/20160922", "name" : {"_value" : "Southwick", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15100/2017:1", "controllerName" : "Adur"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15100/date/20160922/time/125000/recordDate/20160922", "name" : {"_value" : "Southwick", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/southwick", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15100", "easting" : 524358.0, "lat" : 50.8287511053224, "long" : -0.235618077916229, "name" : {"_value" : "Sampling point at Southwick", "_lang" : "en"}
@@ -4017,7 +4168,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2401-15200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15200/date/20160922/time/132900/recordDate/20160922", "name" : {"_value" : "Shoreham Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15200/2017:1", "controllerName" : "Adur"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15200/date/20160922/time/132900/recordDate/20160922", "name" : {"_value" : "Shoreham Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/shoreham-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15200", "easting" : 521848.0, "lat" : 50.8265866683731, "long" : -0.2713284100911, "name" : {"_value" : "Sampling point at Shoreham Beach", "_lang" : "en"}
@@ -4042,7 +4194,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2401-15300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2401-15300/2017:1", "controllerName" : "Adur"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4071,7 +4224,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2407-15400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2407-15400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2407-15400/2017:1", "controllerName" : "Worthing"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4100,7 +4254,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15500/date/20160920/time/101500/recordDate/20160920", "name" : {"_value" : "Littlehampton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15500/2017:1", "controllerName" : "Arun"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15500/date/20160920/time/101500/recordDate/20160920", "name" : {"_value" : "Littlehampton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/littlehampton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15500", "easting" : 503060.0, "lat" : 50.8022939014127, "long" : -0.538868986381269, "name" : {"_value" : "Sampling point at Littlehampton", "_lang" : "en"}
@@ -4125,7 +4280,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15600/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Middleton-on-sea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15600/2017:1", "controllerName" : "Arun"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15600/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Middleton-on-sea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/middleton-on-sea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15600", "easting" : 498500.0, "lat" : 50.7902, "long" : -0.6039, "name" : {"_value" : "Sampling point at Middleton-on-sea", "_lang" : "en"}
@@ -4150,7 +4306,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15650/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15650/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15650/2017:1", "controllerName" : "Arun"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15650/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4179,7 +4336,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15680", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15680/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15680/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15680/date/20160920/time/115000/recordDate/20160920", "name" : {"_value" : "Bognor Regis East", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15680/2017:1", "controllerName" : "Arun"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15680/date/20160920/time/115000/recordDate/20160920", "name" : {"_value" : "Bognor Regis East", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bognor-regis-east", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15680", "easting" : 493900.0, "lat" : 50.7823624879439, "long" : -0.669428029479676, "name" : {"_value" : "Sampling point at Bognor Regis East", "_lang" : "en"}
@@ -4204,7 +4362,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15700/2017:1", "controllerName" : "Arun"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/15700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4233,7 +4392,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2402-15800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15800/date/20160920/time/125000/recordDate/20160920", "name" : {"_value" : "Pagham", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2402-15800/2017:1", "controllerName" : "Arun"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15800/date/20160920/time/125000/recordDate/20160920", "name" : {"_value" : "Pagham", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/pagham", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15800", "easting" : 489200.0, "lat" : 50.7675502319918, "long" : -0.736497732795299, "name" : {"_value" : "Sampling point at Pagham", "_lang" : "en"}
@@ -4258,7 +4418,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2403-15900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/15900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-15900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15900/date/20160920/time/132000/recordDate/20160920", "name" : {"_value" : "Selsey", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-15900/2017:1", "controllerName" : "Chichester"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/15900/date/20160920/time/132000/recordDate/20160920", "name" : {"_value" : "Selsey", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/selsey", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/15900", "easting" : 486872.0, "lat" : 50.7363102526785, "long" : -0.770329030240902, "name" : {"_value" : "Sampling point at Selsey", "_lang" : "en"}
@@ -4283,7 +4444,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2403-16000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-16000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16000/date/20160920/time/135000/recordDate/20160920", "name" : {"_value" : "Bracklesham Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-16000/2017:1", "controllerName" : "Chichester"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16000/date/20160920/time/135000/recordDate/20160920", "name" : {"_value" : "Bracklesham Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bracklesham-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16000", "easting" : 480462.0, "lat" : 50.7610131736483, "long" : -0.860567028233181, "name" : {"_value" : "Sampling point at Bracklesham Bay", "_lang" : "en"}
@@ -4308,7 +4470,8 @@ http_interactions:
               , "eubwidNotation" : "ukj2403-16100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-16100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16100/date/20160920/time/143000/recordDate/20160920", "name" : {"_value" : "West Wittering", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj2403-16100/2017:1", "controllerName" : "Chichester"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16100/date/20160920/time/143000/recordDate/20160920", "name" : {"_value" : "West Wittering", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-wittering", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16100", "easting" : 476800.0, "lat" : 50.776514594016, "long" : -0.912129642146413, "name" : {"_value" : "Sampling point at West Wittering", "_lang" : "en"}
@@ -4333,7 +4496,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3307-16300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16300/date/20160918/time/103000/recordDate/20160918", "name" : {"_value" : "Eastoke", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16300/2017:1", "controllerName" : "Havant"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16300/date/20160918/time/103000/recordDate/20160918", "name" : {"_value" : "Eastoke", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/eastoke", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16300", "easting" : 472900.0, "lat" : 50.7806135959537, "long" : -0.967353980067141, "name" : {"_value" : "Sampling point at Eastoke", "_lang" : "en"}
@@ -4358,7 +4522,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3307-16350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16350/date/20160918/time/104500/recordDate/20160918", "name" : {"_value" : "Beachlands Central", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16350/2017:1", "controllerName" : "Havant"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16350/date/20160918/time/104500/recordDate/20160918", "name" : {"_value" : "Beachlands Central", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/beachlands-central", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16350", "easting" : 471350.0, "lat" : 50.7835933373875, "long" : -0.989275631087487, "name" : {"_value" : "Sampling point at Beachlands Central", "_lang" : "en"}
@@ -4383,7 +4548,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3307-16400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16400/date/20160918/time/105000/recordDate/20160918", "name" : {"_value" : "Beachlands West", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3307-16400/2017:1", "controllerName" : "Havant"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16400/date/20160918/time/105000/recordDate/20160918", "name" : {"_value" : "Beachlands West", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/beachlands-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16400", "easting" : 470500.0, "lat" : 50.7836072294375, "long" : -1.00133285633792, "name" : {"_value" : "Sampling point at Beachlands West", "_lang" : "en"}
@@ -4406,7 +4572,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3100-16500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3100-16500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16500/date/20160918/time/113500/recordDate/20160918", "name" : {"_value" : "Eastney", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3100-16500/2017:1", "controllerName" : "City of Portsmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16500/date/20160918/time/113500/recordDate/20160918", "name" : {"_value" : "Eastney", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/eastney", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16500", "easting" : 467410.0, "lat" : 50.7846394489991, "long" : -1.04514441363308, "name" : {"_value" : "Sampling point at Eastney", "_lang" : "en"}
@@ -4429,7 +4596,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3100-16600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3100-16600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16600/date/20160918/time/115500/recordDate/20160918", "name" : {"_value" : "Southsea East", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3100-16600/2017:1", "controllerName" : "City of Portsmouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16600/date/20160918/time/115500/recordDate/20160918", "name" : {"_value" : "Southsea East", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/southsea-east", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16600", "easting" : 465000.0, "lat" : 50.7786645150506, "long" : -1.07943783420055, "name" : {"_value" : "Sampling point at Southsea East", "_lang" : "en"}
@@ -4454,7 +4622,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3305-16700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3305-16700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/16700/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3305-16700/2017:1", "controllerName" : "Gosport"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/16700/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4483,7 +4652,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3305-16800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3305-16800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16800/date/20160918/time/130500/recordDate/20160918", "name" : {"_value" : "Lee-on-Solent", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3305-16800/2017:1", "controllerName" : "Gosport"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16800/date/20160918/time/130500/recordDate/20160918", "name" : {"_value" : "Lee-on-Solent", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/lee-on-solent", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16800", "easting" : 456172.0, "lat" : 50.8009768984075, "long" : -1.20428418783655, "name" : {"_value" : "Sampling point at Lee-on-Solent", "_lang" : "en"}
@@ -4508,7 +4678,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3304-16850", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16850/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3304-16850/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/16850/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3304-16850/2017:1", "controllerName" : "Fareham"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/16850/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4537,7 +4708,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3308-16900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/16900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-16900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16900/date/20160919/time/125000/recordDate/20160919", "name" : {"_value" : "Calshot", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-16900/2017:1", "controllerName" : "New Forest"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/16900/date/20160919/time/125000/recordDate/20160919", "name" : {"_value" : "Calshot", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/calshot", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/16900", "easting" : 448138.0, "lat" : 50.8093235327237, "long" : -1.31816830680352, "name" : {"_value" : "Sampling point at Calshot", "_lang" : "en"}
@@ -4562,7 +4734,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3308-17000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-17000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17000/date/20160919/time/123000/recordDate/20160919", "name" : {"_value" : "Lepe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-17000/2017:1", "controllerName" : "Hampshire"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17000/date/20160919/time/123000/recordDate/20160919", "name" : {"_value" : "Lepe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/lepe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17000", "easting" : 445600.0, "lat" : 50.784296871071, "long" : -1.35453444846381, "name" : {"_value" : "Sampling point at Lepe", "_lang" : "en"}
@@ -4587,7 +4760,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3308-17100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-17100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17100/date/20160919/time/115000/recordDate/20160919", "name" : {"_value" : "Milford-on-sea", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3308-17100/2017:1", "controllerName" : "New Forest"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17100/date/20160919/time/115000/recordDate/20160919", "name" : {"_value" : "Milford-on-sea", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/milford-on-sea", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17100", "easting" : 427582.0, "lat" : 50.725, "long" : -1.6106, "name" : {"_value" : "Sampling point at Milford-on-sea", "_lang" : "en"}
@@ -4612,7 +4786,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-17200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-17200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17200/date/20160919/time/113000/recordDate/20160919", "name" : {"_value" : "Christchurch Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-17200/2017:1", "controllerName" : "New Forest"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17200/date/20160919/time/113000/recordDate/20160919", "name" : {"_value" : "Christchurch Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/christchurch-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17200", "easting" : 423900.0, "lat" : 50.7343360966257, "long" : -1.66271235419981, "name" : {"_value" : "Sampling point at Christchurch Bay", "_lang" : "en"}
@@ -4637,7 +4812,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-17300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-17300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17300/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Highcliffe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-17300/2017:1", "controllerName" : "Christchurch"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17300/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Highcliffe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/highcliffe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17300", "easting" : 421374.0, "lat" : 50.7369968975496, "long" : -1.69848882701321, "name" : {"_value" : "Sampling point at Highcliffe", "_lang" : "en"}
@@ -4660,7 +4836,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17400/date/20160920/time/120000/recordDate/20160920", "name" : {"_value" : "Compton Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17400/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17400/date/20160920/time/120000/recordDate/20160920", "name" : {"_value" : "Compton Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/compton-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17400", "easting" : 437681.0, "lat" : 50.6560855499202, "long" : -1.46831923617904, "name" : {"_value" : "Sampling point at Compton Bay", "_lang" : "en"}
@@ -4683,7 +4860,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17500/date/20160920/time/113500/recordDate/20160920", "name" : {"_value" : "Totland Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17500/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17500/date/20160920/time/113500/recordDate/20160920", "name" : {"_value" : "Totland Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/totland-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17500", "easting" : 432195.0, "lat" : 50.6808370676852, "long" : -1.54568856715085, "name" : {"_value" : "Sampling point at Totland Bay", "_lang" : "en"}
@@ -4706,7 +4884,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17600/date/20160920/time/111800/recordDate/20160920", "name" : {"_value" : "Colwell Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17600/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/17600/date/20160920/time/111800/recordDate/20160920", "name" : {"_value" : "Colwell Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/colwell-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/17600", "easting" : 432699.0, "lat" : 50.6894777728459, "long" : -1.5384702684968, "name" : {"_value" : "Sampling point at Colwell Bay", "_lang" : "en"}
@@ -4729,7 +4908,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17700/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4756,7 +4936,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17800/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4783,7 +4964,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-17900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/17900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-17900/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/17900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4810,7 +4992,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18000/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4837,7 +5020,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18100/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4864,7 +5048,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18200/date/20160919/time/115700/recordDate/20160919", "name" : {"_value" : "Bembridge", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18200/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18200/date/20160919/time/115700/recordDate/20160919", "name" : {"_value" : "Bembridge", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bembridge", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18200", "easting" : 465817.0, "lat" : 50.686221830107, "long" : -1.0696931248814, "name" : {"_value" : "Sampling point at Bembridge", "_lang" : "en"}
@@ -4887,7 +5072,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18300/date/20160919/time/114000/recordDate/20160919", "name" : {"_value" : "Whitecliff Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18300/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18300/date/20160919/time/114000/recordDate/20160919", "name" : {"_value" : "Whitecliff Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/whitecliff-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18300", "easting" : 464100.0, "lat" : 50.6719546786527, "long" : -1.09427330030781, "name" : {"_value" : "Sampling point at Whitecliff Bay", "_lang" : "en"}
@@ -4910,7 +5096,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18350/date/20160919/time/112400/recordDate/20160919", "name" : {"_value" : "Yaverland", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18350/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18350/date/20160919/time/112400/recordDate/20160919", "name" : {"_value" : "Yaverland", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/yaverland", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18350", "easting" : 461360.0, "lat" : 50.6618190039032, "long" : -1.13323510388486, "name" : {"_value" : "Sampling point at Yaverland", "_lang" : "en"}
@@ -4933,7 +5120,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18400/date/20160919/time/111500/recordDate/20160919", "name" : {"_value" : "Sandown", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18400/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18400/date/20160919/time/111500/recordDate/20160919", "name" : {"_value" : "Sandown", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sandown", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18400", "easting" : 460139.0, "lat" : 50.6549685196269, "long" : -1.150633918919, "name" : {"_value" : "Sampling point at Sandown", "_lang" : "en"}
@@ -4956,7 +5144,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18500/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -4983,7 +5172,8 @@ http_interactions:
               , "eubwidNotation" : "ukj3400-18600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18600/date/20160919/time/101700/recordDate/20160919", "name" : {"_value" : "Ventnor", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukj3400-18600/2017:1", "controllerName" : "Isle of Wight"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18600/date/20160919/time/101700/recordDate/20160919", "name" : {"_value" : "Ventnor", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-east-south-east-office", "name" : {"_value" : "South East", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ventnor", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18600", "easting" : 456018.0, "lat" : 50.5931272563416, "long" : -1.2099676835851, "name" : {"_value" : "Sampling point at Ventnor", "_lang" : "en"}
@@ -5008,7 +5198,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-18700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18700/date/20160921/time/140400/recordDate/20160921", "name" : {"_value" : "Christchurch Highcliffe Castle", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18700/2017:1", "controllerName" : "Christchurch"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18700/date/20160921/time/140400/recordDate/20160921", "name" : {"_value" : "Christchurch Highcliffe Castle", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/christchurch-highcliffe-castle", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18700", "easting" : 420248.0, "lat" : 50.7356521656545, "long" : -1.71445336233307, "name" : {"_value" : "Sampling point at Christchurch Highcliffe Castle", "_lang" : "en"}
@@ -5033,7 +5224,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-18750", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18750/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18750/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18750/date/20160921/time/134200/recordDate/20160921", "name" : {"_value" : "Christchurch Friar`s Cliff", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18750/2017:1", "controllerName" : "Christchurch"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18750/date/20160921/time/134200/recordDate/20160921", "name" : {"_value" : "Christchurch Friar`s Cliff", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/christchurch-friars-cliff", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18750", "easting" : 419194.0, "lat" : 50.7320637415209, "long" : -1.72940964797903, "name" : {"_value" : "Sampling point at Christchurch Friar`s Cliff", "_lang" : "en"}
@@ -5058,7 +5250,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-18800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18800/2017:1", "controllerName" : "Christchurch"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/18800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5087,7 +5280,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2201-18900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/18900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18900/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Christchurch Mudeford Sandbank East", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2201-18900/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/18900/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Christchurch Mudeford Sandbank East", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/christchurch-mudeford-sandbank-east", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/18900", "easting" : 418300.0, "lat" : 50.7192510207495, "long" : -1.7421472862786, "name" : {"_value" : "Sampling point at Christchurch Mudeford Sandbank East", "_lang" : "en"}
@@ -5110,7 +5304,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19000/date/20160921/time/123000/recordDate/20160921", "name" : {"_value" : "Bournemouth Hengistbury West", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19000/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19000/date/20160921/time/123000/recordDate/20160921", "name" : {"_value" : "Bournemouth Hengistbury West", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-hengistbury-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19000", "easting" : 416257.0, "lat" : 50.7168473725383, "long" : -1.77109905009598, "name" : {"_value" : "Sampling point at Bournemouth Hengistbury West", "_lang" : "en"}
@@ -5133,7 +5328,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19020", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19020/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19020/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19020/date/20160921/time/120900/recordDate/20160921", "name" : {"_value" : "Bournemouth Southbourne", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19020/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19020/date/20160921/time/120900/recordDate/20160921", "name" : {"_value" : "Bournemouth Southbourne", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-southbourne", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19020", "easting" : 414800.0, "lat" : 50.7189902745556, "long" : -1.79172760753161, "name" : {"_value" : "Sampling point at Bournemouth Southbourne", "_lang" : "en"}
@@ -5156,7 +5352,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19030", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19030/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19030/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19030/date/20160921/time/115000/recordDate/20160921", "name" : {"_value" : "Bournemouth Fisherman`s Walk", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19030/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19030/date/20160921/time/115000/recordDate/20160921", "name" : {"_value" : "Bournemouth Fisherman`s Walk", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-fishermans-walk", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19030", "easting" : 413024.0, "lat" : 50.7207230391476, "long" : -1.81687860164398, "name" : {"_value" : "Sampling point at Bournemouth Fisherman`s Walk", "_lang" : "en"}
@@ -5179,7 +5376,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19060", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19060/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19060/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/19060/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19060/2017:1", "controllerName" : "Bournemouth"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/19060/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5206,7 +5404,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19100/date/20160921/time/110300/recordDate/20160921", "name" : {"_value" : "Bournemouth Pier", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19100/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19100/date/20160921/time/110300/recordDate/20160921", "name" : {"_value" : "Bournemouth Pier", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-pier", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19100", "easting" : 408860.0, "lat" : 50.7154859312908, "long" : -1.87587923561023, "name" : {"_value" : "Sampling point at Bournemouth Pier", "_lang" : "en"}
@@ -5229,7 +5428,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19150", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19150/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19150/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19150/date/20160921/time/102500/recordDate/20160921", "name" : {"_value" : "Bournemouth Durley Chine", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19150/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19150/date/20160921/time/102500/recordDate/20160921", "name" : {"_value" : "Bournemouth Durley Chine", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-durley-chine", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19150", "easting" : 407951.0, "lat" : 50.713070870982, "long" : -1.88876030554671, "name" : {"_value" : "Sampling point at Bournemouth Durley Chine", "_lang" : "en"}
@@ -5252,7 +5452,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2101-19160", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19160/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19160/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19160/date/20160921/time/101200/recordDate/20160921", "name" : {"_value" : "Bournemouth Alum Chine", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2101-19160/2017:1", "controllerName" : "Bournemouth"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19160/date/20160921/time/101200/recordDate/20160921", "name" : {"_value" : "Bournemouth Alum Chine", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bournemouth-alum-chine", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19160", "easting" : 407481.0, "lat" : 50.7111345968441, "long" : -1.89542148993552, "name" : {"_value" : "Sampling point at Bournemouth Alum Chine", "_lang" : "en"}
@@ -5275,7 +5476,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19170", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19170/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19170/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19170/date/20160926/time/105100/recordDate/20160926", "name" : {"_value" : "Poole Branksome Chine", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19170/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19170/date/20160926/time/105100/recordDate/20160926", "name" : {"_value" : "Poole Branksome Chine", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-branksome-chine", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19170", "easting" : 406455.0, "lat" : 50.7059129455387, "long" : -1.9099627041663, "name" : {"_value" : "Sampling point at Poole Branksome Chine", "_lang" : "en"}
@@ -5298,7 +5500,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19190", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19190/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19190/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19190/date/20160926/time/110500/recordDate/20160926", "name" : {"_value" : "Poole Canford Cliffs Chine", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19190/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19190/date/20160926/time/110500/recordDate/20160926", "name" : {"_value" : "Poole Canford Cliffs Chine", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-canford-cliffs-chine", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19190", "easting" : 405710.0, "lat" : 50.7004710167838, "long" : -1.92052213571419, "name" : {"_value" : "Sampling point at Poole Canford Cliffs Chine", "_lang" : "en"}
@@ -5321,7 +5524,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19200/date/20160926/time/111800/recordDate/20160926", "name" : {"_value" : "Poole Shore Road Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19200/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19200/date/20160926/time/111800/recordDate/20160926", "name" : {"_value" : "Poole Shore Road Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-shore-road-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19200", "easting" : 405085.0, "lat" : 50.6946674055625, "long" : -1.92938068365715, "name" : {"_value" : "Sampling point at Poole Shore Road Beach", "_lang" : "en"}
@@ -5344,7 +5548,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19350", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19350/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19350/date/20160926/time/115200/recordDate/20160926", "name" : {"_value" : "Poole Sandbanks Peninsular", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19350/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19350/date/20160926/time/115200/recordDate/20160926", "name" : {"_value" : "Poole Sandbanks Peninsular", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-sandbanks-peninsular", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19350", "easting" : 404520.0, "lat" : 50.6887007951396, "long" : -1.93738788221216, "name" : {"_value" : "Sampling point at Poole Sandbanks Peninsular", "_lang" : "en"}
@@ -5367,7 +5572,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19400/date/20160926/time/101300/recordDate/20160926", "name" : {"_value" : "Poole Harbour Lake", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19400/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19400/date/20160926/time/101300/recordDate/20160926", "name" : {"_value" : "Poole Harbour Lake", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-harbour-lake", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19400", "easting" : 398313.0, "lat" : 50.7138492148326, "long" : -2.02526943121092, "name" : {"_value" : "Sampling point at Poole Harbour Lake", "_lang" : "en"}
@@ -5390,7 +5596,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2102-19450", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19450/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19450/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19450/date/20160926/time/100000/recordDate/20160926", "name" : {"_value" : "Poole Harbour Rockley Sands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2102-19450/2017:1", "controllerName" : "Poole"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19450/date/20160926/time/100000/recordDate/20160926", "name" : {"_value" : "Poole Harbour Rockley Sands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poole-harbour-rockley-sands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19450", "easting" : 397263.0, "lat" : 50.719330531449, "long" : -2.04014616943396, "name" : {"_value" : "Sampling point at Poole Harbour Rockley Sands", "_lang" : "en"}
@@ -5415,7 +5622,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-19600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19600/date/20160926/time/121800/recordDate/20160926", "name" : {"_value" : "Shell Bay North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19600/2017:1", "controllerName" : "Purbeck"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19600/date/20160926/time/121800/recordDate/20160926", "name" : {"_value" : "Shell Bay North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/shell-bay-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19600", "easting" : 403714.0, "lat" : 50.6784546277685, "long" : -1.94880889880762, "name" : {"_value" : "Sampling point at Shell Bay North", "_lang" : "en"}
@@ -5440,7 +5648,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-19700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19700/date/20160926/time/123700/recordDate/20160926", "name" : {"_value" : "Studland Knoll House", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19700/2017:1", "controllerName" : "Purbeck"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19700/date/20160926/time/123700/recordDate/20160926", "name" : {"_value" : "Studland Knoll House", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/studland-knoll-house", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19700", "easting" : 403430.0, "lat" : 50.6520985551084, "long" : -1.95285461153164, "name" : {"_value" : "Sampling point at Studland Knoll House", "_lang" : "en"}
@@ -5465,7 +5674,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-19800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19800/date/20160926/time/130000/recordDate/20160926", "name" : {"_value" : "Swanage Central", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19800/2017:1", "controllerName" : "Swanage"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/19800/date/20160926/time/130000/recordDate/20160926", "name" : {"_value" : "Swanage Central", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/swanage-central", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/19800", "easting" : 403102.0, "lat" : 50.6134402645265, "long" : -1.95752882593927, "name" : {"_value" : "Sampling point at Swanage Central", "_lang" : "en"}
@@ -5490,7 +5700,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-19900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/19900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/19900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19900/2017:1", "controllerName" : "Purbeck"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/19900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5519,7 +5730,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-20000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20000/2017:1", "controllerName" : "Purbeck"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5548,7 +5760,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-20100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20100/date/20160922/time/120900/recordDate/20160922", "name" : {"_value" : "Durdle Door East", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20100/2017:1", "controllerName" : "Purbeck"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20100/date/20160922/time/120900/recordDate/20160922", "name" : {"_value" : "Durdle Door East", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/durdle-door-east", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20100", "easting" : 380703.0, "lat" : 50.6220094769958, "long" : -2.27415859053492, "name" : {"_value" : "Sampling point at Durdle Door East", "_lang" : "en"}
@@ -5573,7 +5786,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2204-20200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20200/date/20160922/time/115900/recordDate/20160922", "name" : {"_value" : "Durdle Door West", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-20200/2017:1", "controllerName" : "Purbeck"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20200/date/20160922/time/115900/recordDate/20160922", "name" : {"_value" : "Durdle Door West", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/durdle-door-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20200", "easting" : 380493.0, "lat" : 50.6219484895418, "long" : -2.27712684482216, "name" : {"_value" : "Sampling point at Durdle Door West", "_lang" : "en"}
@@ -5598,7 +5812,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20300/date/20160922/time/111200/recordDate/20160922", "name" : {"_value" : "Ringstead Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20300/2017:1", "controllerName" : "West Dorset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20300/date/20160922/time/111200/recordDate/20160922", "name" : {"_value" : "Ringstead Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ringstead-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20300", "easting" : 375246.0, "lat" : 50.6310556486312, "long" : -2.35136765080147, "name" : {"_value" : "Sampling point at Ringstead Bay", "_lang" : "en"}
@@ -5623,7 +5838,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20400/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5652,7 +5868,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20500/date/20160923/time/152900/recordDate/20160923", "name" : {"_value" : "Church Ope Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20500/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20500/date/20160923/time/152900/recordDate/20160923", "name" : {"_value" : "Church Ope Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/church-ope-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20500", "easting" : 369760.0, "lat" : 50.5379917922919, "long" : -2.42808894091769, "name" : {"_value" : "Sampling point at Church Ope Cove", "_lang" : "en"}
@@ -5677,7 +5894,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20600/date/20160922/time/102800/recordDate/20160922", "name" : {"_value" : "Weymouth Lodmoor", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20600/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20600/date/20160922/time/102800/recordDate/20160922", "name" : {"_value" : "Weymouth Lodmoor", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/weymouth-lodmoor", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20600", "easting" : 368820.0, "lat" : 50.6258900329473, "long" : -2.44217637595214, "name" : {"_value" : "Sampling point at Weymouth Lodmoor", "_lang" : "en"}
@@ -5702,7 +5920,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20700/date/20160922/time/101300/recordDate/20160922", "name" : {"_value" : "Weymouth Central", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20700/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20700/date/20160922/time/101300/recordDate/20160922", "name" : {"_value" : "Weymouth Central", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/weymouth-central", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20700", "easting" : 368100.0, "lat" : 50.6144663711725, "long" : -2.45224570274321, "name" : {"_value" : "Sampling point at Weymouth Central", "_lang" : "en"}
@@ -5727,7 +5946,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/11", "name" : {"_value" : "Closed", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20800/2017:1", "latestSampleAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20800/date/20140922/time/135200/recordDate/20140922", "sampleClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2012/G", "name" : {"_value" : "Higher", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20800/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestSampleAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20800/date/20140922/time/135200/recordDate/20140922", "sampleClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2012/G", "name" : {"_value" : "Higher", "_lang" : "en"}
                 }
               }
               , "name" : {"_value" : "Portland Harbour Castle Cove", "_lang" : "en"}
@@ -5755,7 +5975,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2206-20900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2206-20900/2017:1", "controllerName" : "Weymouth and Portland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/20900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5784,7 +6005,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-20970", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/20970/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-20970/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20970/date/20160923/time/141300/recordDate/20160923", "name" : {"_value" : "Hive", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-20970/2017:1", "controllerName" : "West Dorset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/20970/date/20160923/time/141300/recordDate/20160923", "name" : {"_value" : "Hive", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hive", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/20970", "easting" : 349016.0, "lat" : 50.6962649935347, "long" : -2.72323664973336, "name" : {"_value" : "Sampling point at Hive", "_lang" : "en"}
@@ -5809,7 +6031,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-21000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21000/date/20160923/time/132700/recordDate/20160923", "name" : {"_value" : "West Bay (West)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21000/2017:1", "controllerName" : "West Dorset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21000/date/20160923/time/132700/recordDate/20160923", "name" : {"_value" : "West Bay (West)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/west-bay-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/21000", "easting" : 345974.0, "lat" : 50.7109881993129, "long" : -2.76654773414885, "name" : {"_value" : "Sampling point at West Bay (West)", "_lang" : "en"}
@@ -5834,7 +6057,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-21100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21100/date/20160923/time/125700/recordDate/20160923", "name" : {"_value" : "Eypemouth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21100/2017:1", "controllerName" : "West Dorset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21100/date/20160923/time/125700/recordDate/20160923", "name" : {"_value" : "Eypemouth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/eypemouth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/21100", "easting" : 344685.0, "lat" : 50.7161089362555, "long" : -2.78488967571793, "name" : {"_value" : "Sampling point at Eypemouth", "_lang" : "en"}
@@ -5859,7 +6083,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-21200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21200/date/20160923/time/122600/recordDate/20160923", "name" : {"_value" : "Seatown", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21200/2017:1", "controllerName" : "West Dorset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21200/date/20160923/time/122600/recordDate/20160923", "name" : {"_value" : "Seatown", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/seatown", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/21200", "easting" : 341873.0, "lat" : 50.7221101381266, "long" : -2.82482642610957, "name" : {"_value" : "Sampling point at Seatown", "_lang" : "en"}
@@ -5884,7 +6109,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-21300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21300/2017:1", "controllerName" : "West Dorset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5913,7 +6139,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2205-21500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2205-21500/2017:1", "controllerName" : "West Dorset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5948,7 +6175,8 @@ http_interactions:
                 , "nirsRef" : "99998888", "som_recordDateTime" : {"_value" : "2017-08-03T13:48:11", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-08-03T13:30:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21600/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -5977,7 +6205,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4301-21700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21700/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6006,7 +6235,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4301-21800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21800/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/21800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6035,7 +6265,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4301-21900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/21900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21900/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Sidmouth Jacobs Ladder", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-21900/2017:1", "controllerName" : "East Devon"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/21900/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Sidmouth Jacobs Ladder", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sidmouth-jacobs-ladder", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/21900", "easting" : 311920.0, "lat" : 50.6752708713685, "long" : -3.24791989088234, "name" : {"_value" : "Sampling point at Sidmouth Jacobs Ladder", "_lang" : "en"}
@@ -6060,7 +6291,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4301-22000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/22000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22000/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6100,7 +6332,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T16:49:03", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T16:45:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22100/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6129,7 +6362,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4301-22200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/22200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22200/date/20160919/time/123000/recordDate/20160919", "name" : {"_value" : "Sandy Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22200/2017:1", "controllerName" : "East Devon"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22200/date/20160919/time/123000/recordDate/20160919", "name" : {"_value" : "Sandy Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sandy-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/22200", "easting" : 303300.0, "lat" : 50.6098814242925, "long" : -3.36801763242127, "name" : {"_value" : "Sampling point at Sandy Bay", "_lang" : "en"}
@@ -6160,7 +6394,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T16:49:03", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T16:45:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4301-22300/2017:1", "controllerName" : "East Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6195,7 +6430,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:58:14", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:55:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22400/date/20160920/time/103500/recordDate/20160920", "name" : {"_value" : "Dawlish Warren", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22400/2017:1", "controllerName" : "Teignbridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22400/date/20160920/time/103500/recordDate/20160920", "name" : {"_value" : "Dawlish Warren", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/dawlish-warren", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/22400", "easting" : 298260.0, "lat" : 50.5996735928448, "long" : -3.43893853887074, "name" : {"_value" : "Sampling point at Dawlish Warren", "_lang" : "en"}
@@ -6226,7 +6462,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:58:14", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:55:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22500/2017:1", "controllerName" : "Teignbridge"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6255,7 +6492,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4306-22600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/22600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22600/date/20160920/time/112500/recordDate/20160920", "name" : {"_value" : "Dawlish Coryton Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22600/2017:1", "controllerName" : "Teignbridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22600/date/20160920/time/112500/recordDate/20160920", "name" : {"_value" : "Dawlish Coryton Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/dawlish-coryton-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/22600", "easting" : 296110.0, "lat" : 50.5748417973404, "long" : -3.46854598688217, "name" : {"_value" : "Sampling point at Dawlish Coryton Cove", "_lang" : "en"}
@@ -6280,7 +6518,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4306-22700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/22700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22700/date/20160920/time/114500/recordDate/20160920", "name" : {"_value" : "Teignmouth Holcombe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22700/2017:1", "controllerName" : "Teignbridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/22700/date/20160920/time/114500/recordDate/20160920", "name" : {"_value" : "Teignmouth Holcombe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/teignmouth-holcombe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/22700", "easting" : 295650.0, "lat" : 50.5619041154044, "long" : -3.47463850962763, "name" : {"_value" : "Sampling point at Teignmouth Holcombe", "_lang" : "en"}
@@ -6311,7 +6550,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:48:12", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:45:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22800/2017:1", "controllerName" : "Teignbridge"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6346,7 +6586,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:48:12", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:45:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-22900/2017:1", "controllerName" : "Teignbridge"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/22900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6375,7 +6616,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4306-23000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-23000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23000/date/20160920/time/124000/recordDate/20160920", "name" : {"_value" : "Ness Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4306-23000/2017:1", "controllerName" : "Teignbridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23000/date/20160920/time/124000/recordDate/20160920", "name" : {"_value" : "Ness Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ness-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23000", "easting" : 293925.0, "lat" : 50.5361159346401, "long" : -3.4981762447304, "name" : {"_value" : "Sampling point at Ness Cove", "_lang" : "en"}
@@ -6398,7 +6640,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23100/date/20160920/time/132000/recordDate/20160920", "name" : {"_value" : "Maidencombe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23100/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23100/date/20160920/time/132000/recordDate/20160920", "name" : {"_value" : "Maidencombe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/maidencombe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23100", "easting" : 292780.0, "lat" : 50.5064562259524, "long" : -3.51338465782657, "name" : {"_value" : "Sampling point at Maidencombe", "_lang" : "en"}
@@ -6421,7 +6664,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23200/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6448,7 +6692,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23300/date/20160920/time/140000/recordDate/20160920", "name" : {"_value" : "Oddicombe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23300/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23300/date/20160920/time/140000/recordDate/20160920", "name" : {"_value" : "Oddicombe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/oddicombe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23300", "easting" : 292619.0, "lat" : 50.4824686796969, "long" : -3.51488751237418, "name" : {"_value" : "Sampling point at Oddicombe", "_lang" : "en"}
@@ -6471,7 +6716,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23400/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6498,7 +6744,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23501", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23501/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23501/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23501/date/20160921/time/123200/recordDate/20160921", "name" : {"_value" : "Anstey's Cove (Torquay)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23501/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23501/date/20160921/time/123200/recordDate/20160921", "name" : {"_value" : "Anstey's Cove (Torquay)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ansteys-cove-torquay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23501", "easting" : 293574.0, "lat" : 50.4718461526252, "long" : -3.50108973053771, "name" : {"_value" : "Sampling point at Anstey's Cove (Torquay)", "_lang" : "en"}
@@ -6521,7 +6768,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23600/date/20160921/time/121600/recordDate/20160921", "name" : {"_value" : "Meadfoot", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23600/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23600/date/20160921/time/121600/recordDate/20160921", "name" : {"_value" : "Meadfoot", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/meadfoot", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23600", "easting" : 292964.0, "lat" : 50.457100334341, "long" : -3.50920608022892, "name" : {"_value" : "Sampling point at Meadfoot", "_lang" : "en"}
@@ -6544,7 +6792,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23700/date/20160921/time/120500/recordDate/20160921", "name" : {"_value" : "Beacon Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23700/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/23700/date/20160921/time/120500/recordDate/20160921", "name" : {"_value" : "Beacon Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/beacon-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/23700", "easting" : 291950.0, "lat" : 50.4574885725162, "long" : -3.52351410410433, "name" : {"_value" : "Sampling point at Beacon Cove", "_lang" : "en"}
@@ -6573,7 +6822,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T17:20:30", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T17:17:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23800/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6600,7 +6850,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-23900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/23900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-23900/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/23900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6627,7 +6878,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-24000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24000/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6660,7 +6912,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T17:20:30", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T17:17:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24100/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6687,7 +6940,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-24200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24200/2017:1", "controllerName" : "Torbay"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/24200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6714,7 +6968,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-24300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24300/date/20160921/time/143200/recordDate/20160921", "name" : {"_value" : "Broadsands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24300/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24300/date/20160921/time/143200/recordDate/20160921", "name" : {"_value" : "Broadsands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/broadsands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24300", "easting" : 289642.0, "lat" : 50.4060232848898, "long" : -3.5543427608734, "name" : {"_value" : "Sampling point at Broadsands", "_lang" : "en"}
@@ -6737,7 +6992,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-24500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24500/date/20160921/time/150000/recordDate/20160921", "name" : {"_value" : "Breakwater Beach (Shoalstone)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24500/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24500/date/20160921/time/150000/recordDate/20160921", "name" : {"_value" : "Breakwater Beach (Shoalstone)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/breakwater-beach-shoalstone", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24500", "easting" : 293170.0, "lat" : 50.4000863050536, "long" : -3.50450585727642, "name" : {"_value" : "Sampling point at Breakwater Beach (Shoalstone)", "_lang" : "en"}
@@ -6760,7 +7016,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4200-24600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24600/date/20160921/time/152200/recordDate/20160921", "name" : {"_value" : "St Mary's Bay (Devon)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4200-24600/2017:1", "controllerName" : "Torbay"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24600/date/20160921/time/152200/recordDate/20160921", "name" : {"_value" : "St Mary's Bay (Devon)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/st-marys-bay-devon", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24600", "easting" : 293200.0, "lat" : 50.3852581354791, "long" : -3.50361446794103, "name" : {"_value" : "Sampling point at St Mary's Bay (Devon)", "_lang" : "en"}
@@ -6785,7 +7042,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-24700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24700/date/20160922/time/125500/recordDate/20160922", "name" : {"_value" : "Dartmouth Castle and Sugary Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24700/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24700/date/20160922/time/125500/recordDate/20160922", "name" : {"_value" : "Dartmouth Castle and Sugary Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/dartmouth-castle-and-sugary-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24700", "easting" : 288700.0, "lat" : 50.3420804667083, "long" : -3.56549282824257, "name" : {"_value" : "Sampling point at Dartmouth Castle and Sugary Cove", "_lang" : "en"}
@@ -6810,7 +7068,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-24800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24800/date/20160922/time/124000/recordDate/20160922", "name" : {"_value" : "Blackpool Sands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24800/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24800/date/20160922/time/124000/recordDate/20160922", "name" : {"_value" : "Blackpool Sands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/blackpool-sands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24800", "easting" : 285500.0, "lat" : 50.3194415592079, "long" : -3.60970013678095, "name" : {"_value" : "Sampling point at Blackpool Sands", "_lang" : "en"}
@@ -6835,7 +7094,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-24900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/24900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24900/date/20160922/time/122000/recordDate/20160922", "name" : {"_value" : "Slapton Sands Monument", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-24900/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/24900/date/20160922/time/122000/recordDate/20160922", "name" : {"_value" : "Slapton Sands Monument", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/slapton-sands-monument", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/24900", "easting" : 282900.0, "lat" : 50.2859383650832, "long" : -3.64506666217138, "name" : {"_value" : "Sampling point at Slapton Sands Monument", "_lang" : "en"}
@@ -6860,7 +7120,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25000/date/20160922/time/121000/recordDate/20160922", "name" : {"_value" : "Slapton Sands Torcross", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25000/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25000/date/20160922/time/121000/recordDate/20160922", "name" : {"_value" : "Slapton Sands Torcross", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/slapton-sands-torcross", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/25000", "easting" : 282350.0, "lat" : 50.2662314933333, "long" : -3.65210482762187, "name" : {"_value" : "Sampling point at Slapton Sands Torcross", "_lang" : "en"}
@@ -6885,7 +7146,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25100/date/20160922/time/114000/recordDate/20160922", "name" : {"_value" : "Mill Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25100/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25100/date/20160922/time/114000/recordDate/20160922", "name" : {"_value" : "Mill Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/mill-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/25100", "easting" : 274070.0, "lat" : 50.2300039657805, "long" : -3.76694720248013, "name" : {"_value" : "Sampling point at Mill Bay", "_lang" : "en"}
@@ -6910,7 +7172,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25200/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6939,7 +7202,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25300/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -6968,7 +7232,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25400/date/20160922/time/101000/recordDate/20160922", "name" : {"_value" : "Hope Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25400/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25400/date/20160922/time/101000/recordDate/20160922", "name" : {"_value" : "Hope Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hope-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/25400", "easting" : 267532.0, "lat" : 50.2426503738911, "long" : -3.85911026105057, "name" : {"_value" : "Sampling point at Hope Cove", "_lang" : "en"}
@@ -6993,7 +7258,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25500/date/20160923/time/105000/recordDate/20160923", "name" : {"_value" : "Thurlestone South", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25500/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25500/date/20160923/time/105000/recordDate/20160923", "name" : {"_value" : "Thurlestone South", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/thurlestone-south", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/25500", "easting" : 267650.0, "lat" : 50.2604204594602, "long" : -3.8581465942212, "name" : {"_value" : "Sampling point at Thurlestone South", "_lang" : "en"}
@@ -7018,7 +7284,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25600/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7047,7 +7314,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25700/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7076,7 +7344,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25800/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/25800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7105,7 +7374,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-25900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/25900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25900/date/20160923/time/113000/recordDate/20160923", "name" : {"_value" : "Bigbury-on-Sea North", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-25900/2017:1", "controllerName" : "South Hams"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/25900/date/20160923/time/113000/recordDate/20160923", "name" : {"_value" : "Bigbury-on-Sea North", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bigbury-on-sea-north", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/25900", "easting" : 264950.0, "lat" : 50.2831786856372, "long" : -3.89693283004622, "name" : {"_value" : "Sampling point at Bigbury-on-Sea North", "_lang" : "en"}
@@ -7130,7 +7400,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-26000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26000/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7159,7 +7430,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-26100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26100/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7188,7 +7460,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-26200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26200/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7217,7 +7490,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4305-26300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4305-26300/2017:1", "controllerName" : "South Hams"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7250,7 +7524,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:37:08", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4100-26400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4100-26400/2017:1", "controllerName" : "City of Plymouth"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7283,7 +7558,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-05-02T18:37:08", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-05-02T18:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4100-26500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4100-26500/2017:1", "controllerName" : "City of Plymouth"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7310,7 +7586,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26520", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26520/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26520/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26520/date/20160920/time/101500/recordDate/20160920", "name" : {"_value" : "Kingsand", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26520/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26520/date/20160920/time/101500/recordDate/20160920", "name" : {"_value" : "Kingsand", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/kingsand", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/26520", "easting" : 243570.0, "lat" : 50.3336128930897, "long" : -4.19937582310552, "name" : {"_value" : "Sampling point at Kingsand", "_lang" : "en"}
@@ -7333,7 +7610,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26530", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26530/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26530/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26530/date/20160920/time/102500/recordDate/20160920", "name" : {"_value" : "Cawsand", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26530/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26530/date/20160920/time/102500/recordDate/20160920", "name" : {"_value" : "Cawsand", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/cawsand", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/26530", "easting" : 243420.0, "lat" : 50.3308770287535, "long" : -4.20135718723489, "name" : {"_value" : "Sampling point at Cawsand", "_lang" : "en"}
@@ -7356,7 +7634,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26570", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26570/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/11", "name" : {"_value" : "Closed", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26570/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26570/date/20150817/time/142500/recordDate/20150817", "name" : {"_value" : "Whitsand Bay (Sharrow)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26570/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26570/date/20150817/time/142500/recordDate/20150817", "name" : {"_value" : "Whitsand Bay (Sharrow)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/whitsand-bay-sharrow", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/26570", "easting" : 239330.0, "lat" : 50.3476, "long" : -4.2596, "name" : {"_value" : "Sampling point at Whitsand Bay (Sharrow)", "_lang" : "en"}
@@ -7379,7 +7658,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26600/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Portwrinkle", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26600/date/20160920/time/105000/recordDate/20160920", "name" : {"_value" : "Portwrinkle", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/portwrinkle", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/26600", "easting" : 235960.0, "lat" : 50.3614649870999, "long" : -4.30766544034371, "name" : {"_value" : "Sampling point at Portwrinkle", "_lang" : "en"}
@@ -7402,7 +7682,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26700/date/20160920/time/110500/recordDate/20160920", "name" : {"_value" : "Downderry", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26700/date/20160920/time/110500/recordDate/20160920", "name" : {"_value" : "Downderry", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/downderry", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/26700", "easting" : 231470.0, "lat" : 50.3610043414486, "long" : -4.37077575632986, "name" : {"_value" : "Sampling point at Downderry", "_lang" : "en"}
@@ -7425,7 +7706,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26800/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7452,7 +7734,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-26900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/26900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26900/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/26900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7479,7 +7762,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3101-27000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-27000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-27000/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7506,7 +7790,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27100/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7533,7 +7818,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27200/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7560,7 +7846,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27300/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7587,7 +7874,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27400/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/27400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7614,7 +7902,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27500/date/20160921/time/101500/recordDate/20160921", "name" : {"_value" : "Crinnis", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27500/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27500/date/20160921/time/101500/recordDate/20160921", "name" : {"_value" : "Crinnis", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/crinnis", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/27500", "easting" : 205550.0, "lat" : 50.3361204799296, "long" : -4.73381042662777, "name" : {"_value" : "Sampling point at Crinnis", "_lang" : "en"}
@@ -7637,7 +7926,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27600/date/20160921/time/102500/recordDate/20160921", "name" : {"_value" : "Charlestown", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27600/date/20160921/time/102500/recordDate/20160921", "name" : {"_value" : "Charlestown", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/charlestown", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/27600", "easting" : 204000.0, "lat" : 50.3312049763154, "long" : -4.75530986762393, "name" : {"_value" : "Sampling point at Charlestown", "_lang" : "en"}
@@ -7660,7 +7950,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27700/date/20160921/time/104500/recordDate/20160921", "name" : {"_value" : "Duporth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27700/date/20160921/time/104500/recordDate/20160921", "name" : {"_value" : "Duporth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/duporth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/27700", "easting" : 203520.0, "lat" : 50.3274519056748, "long" : -4.7618374566786, "name" : {"_value" : "Sampling point at Duporth", "_lang" : "en"}
@@ -7683,7 +7974,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27800/date/20160921/time/110000/recordDate/20160921", "name" : {"_value" : "Porthpean", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27800/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27800/date/20160921/time/110000/recordDate/20160921", "name" : {"_value" : "Porthpean", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthpean", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/27800", "easting" : 203230.0, "lat" : 50.323582322786, "long" : -4.76568765910925, "name" : {"_value" : "Sampling point at Porthpean", "_lang" : "en"}
@@ -7706,7 +7998,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-27900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/27900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27900/date/20160921/time/112000/recordDate/20160921", "name" : {"_value" : "Pentewan", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27900/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/27900/date/20160921/time/112000/recordDate/20160921", "name" : {"_value" : "Pentewan", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/pentewan", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/27900", "easting" : 201880.0, "lat" : 50.2875583923612, "long" : -4.78255130253817, "name" : {"_value" : "Sampling point at Pentewan", "_lang" : "en"}
@@ -7729,7 +8022,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-28000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28000/date/20160921/time/114000/recordDate/20160921", "name" : {"_value" : "Polstreath", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28000/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28000/date/20160921/time/114000/recordDate/20160921", "name" : {"_value" : "Polstreath", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/polstreath", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/28000", "easting" : 201710.0, "lat" : 50.2743864942043, "long" : -4.78416897141297, "name" : {"_value" : "Sampling point at Polstreath", "_lang" : "en"}
@@ -7752,7 +8046,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-28100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28100/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7779,7 +8074,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-28200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28200/2017:1", "controllerName" : "St Goran"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7806,7 +8102,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-28300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28300/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Gorran Haven (Vault)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28300/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28300/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Gorran Haven (Vault)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/gorran-haven-vault", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/28300", "easting" : 201300.0, "lat" : 50.2349042272139, "long" : -4.78761701530411, "name" : {"_value" : "Sampling point at Gorran Haven (Vault)", "_lang" : "en"}
@@ -7829,7 +8126,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-28400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28400/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7856,7 +8154,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-28500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28500/date/20160921/time/141000/recordDate/20160921", "name" : {"_value" : "Pendower", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28500/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28500/date/20160921/time/141000/recordDate/20160921", "name" : {"_value" : "Pendower", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/pendower", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/28500", "easting" : 189750.0, "lat" : 50.2056700645544, "long" : -4.94779756978228, "name" : {"_value" : "Sampling point at Pendower", "_lang" : "en"}
@@ -7879,7 +8178,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-28550", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28550/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28550/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28550/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28550/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28550/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7906,7 +8206,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-28600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28600/date/20160924/time/100000/recordDate/20160924", "name" : {"_value" : "Gyllyngvase", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28600/date/20160924/time/100000/recordDate/20160924", "name" : {"_value" : "Gyllyngvase", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/gyllyngvase", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/28600", "easting" : 180940.0, "lat" : 50.1446385955148, "long" : -5.06736772446128, "name" : {"_value" : "Sampling point at Gyllyngvase", "_lang" : "en"}
@@ -7929,7 +8230,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-28700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28700/date/20160924/time/101000/recordDate/20160924", "name" : {"_value" : "Swanpool", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/28700/date/20160924/time/101000/recordDate/20160924", "name" : {"_value" : "Swanpool", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/swanpool", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/28700", "easting" : 180320.0, "lat" : 50.1406373490229, "long" : -5.07579001240729, "name" : {"_value" : "Sampling point at Swanpool", "_lang" : "en"}
@@ -7952,7 +8254,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-28800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28800/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -7979,7 +8282,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-28900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/28900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-28900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-28900/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/28900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8006,7 +8310,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29000/date/20160924/time/113000/recordDate/20160924", "name" : {"_value" : "Porthoustock", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29000/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29000/date/20160924/time/113000/recordDate/20160924", "name" : {"_value" : "Porthoustock", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthoustock", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29000", "easting" : 180760.0, "lat" : 50.0555729641758, "long" : -5.06419511534881, "name" : {"_value" : "Sampling point at Porthoustock", "_lang" : "en"}
@@ -8029,7 +8334,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29100/date/20160924/time/114500/recordDate/20160924", "name" : {"_value" : "Coverack", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29100/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29100/date/20160924/time/114500/recordDate/20160924", "name" : {"_value" : "Coverack", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/coverack", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29100", "easting" : 178260.0, "lat" : 50.024381672247, "long" : -5.09711731719632, "name" : {"_value" : "Sampling point at Coverack", "_lang" : "en"}
@@ -8052,7 +8358,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29200/date/20160924/time/120500/recordDate/20160924", "name" : {"_value" : "Kennack Sands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29200/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29200/date/20160924/time/120500/recordDate/20160924", "name" : {"_value" : "Kennack Sands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/kennack-sands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29200", "easting" : 173410.0, "lat" : 50.0051345550698, "long" : -5.16357592477975, "name" : {"_value" : "Sampling point at Kennack Sands", "_lang" : "en"}
@@ -8075,7 +8382,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29400/date/20160924/time/123500/recordDate/20160924", "name" : {"_value" : "Polurrian Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29400/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29400/date/20160924/time/123500/recordDate/20160924", "name" : {"_value" : "Polurrian Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/polurrian-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29400", "easting" : 166860.0, "lat" : 50.0233499057156, "long" : -5.25623485684049, "name" : {"_value" : "Sampling point at Polurrian Cove", "_lang" : "en"}
@@ -8098,7 +8406,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29500/date/20160924/time/125500/recordDate/20160924", "name" : {"_value" : "Poldhu Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29500/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29500/date/20160924/time/125500/recordDate/20160924", "name" : {"_value" : "Poldhu Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/poldhu-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29500", "easting" : 166550.0, "lat" : 50.0335544983364, "long" : -5.26125534124518, "name" : {"_value" : "Sampling point at Poldhu Cove", "_lang" : "en"}
@@ -8121,7 +8430,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29501", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29501/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29501/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29501/date/20160924/time/131500/recordDate/20160924", "name" : {"_value" : "Church Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29501/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29501/date/20160924/time/131500/recordDate/20160924", "name" : {"_value" : "Church Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/church-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29501", "easting" : 166100.0, "lat" : 50.0385857260958, "long" : -5.26788220436883, "name" : {"_value" : "Sampling point at Church Cove", "_lang" : "en"}
@@ -8144,7 +8454,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29800/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "Porthleven West", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29800/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29800/date/20160925/time/100000/recordDate/20160925", "name" : {"_value" : "Porthleven West", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthleven-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29800", "easting" : 162950.0, "lat" : 50.0810654983874, "long" : -5.31481129754882, "name" : {"_value" : "Sampling point at Porthleven West", "_lang" : "en"}
@@ -8167,7 +8478,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-29900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/29900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29900/date/20160925/time/102500/recordDate/20160925", "name" : {"_value" : "Praa Sands East", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29900/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/29900/date/20160925/time/102500/recordDate/20160925", "name" : {"_value" : "Praa Sands East", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/praa-sands-east", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/29900", "easting" : 158470.0, "lat" : 50.0992826747151, "long" : -5.37872709464994, "name" : {"_value" : "Sampling point at Praa Sands East", "_lang" : "en"}
@@ -8190,7 +8502,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-30000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-30000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30000/date/20160925/time/104500/recordDate/20160925", "name" : {"_value" : "Praa Sands West", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-30000/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30000/date/20160925/time/104500/recordDate/20160925", "name" : {"_value" : "Praa Sands West", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/praa-sands-west", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30000", "easting" : 157620.0, "lat" : 50.1032457805843, "long" : -5.39089540088006, "name" : {"_value" : "Sampling point at Praa Sands West", "_lang" : "en"}
@@ -8213,7 +8526,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30100/date/20160925/time/110000/recordDate/20160925", "name" : {"_value" : "Perranuthnoe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30100/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30100/date/20160925/time/110000/recordDate/20160925", "name" : {"_value" : "Perranuthnoe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/perranuthnoe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30100", "easting" : 153980.0, "lat" : 50.1122525406346, "long" : -5.44245580831161, "name" : {"_value" : "Sampling point at Perranuthnoe", "_lang" : "en"}
@@ -8236,7 +8550,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30200/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8263,7 +8578,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30300/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8290,7 +8606,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30400/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8317,7 +8634,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30500/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/30500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8344,7 +8662,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30600/date/20160925/time/134000/recordDate/20160925", "name" : {"_value" : "Porthcurno", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30600/date/20160925/time/134000/recordDate/20160925", "name" : {"_value" : "Porthcurno", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthcurno", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30600", "easting" : 138740.0, "lat" : 50.0429147873402, "long" : -5.65039285876609, "name" : {"_value" : "Sampling point at Porthcurno", "_lang" : "en"}
@@ -8367,7 +8686,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30700/date/20160925/time/141500/recordDate/20160925", "name" : {"_value" : "Sennen", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30700/date/20160925/time/141500/recordDate/20160925", "name" : {"_value" : "Sennen", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/sennen", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30700", "easting" : 135560.0, "lat" : 50.0787565561387, "long" : -5.69757684991096, "name" : {"_value" : "Sampling point at Sennen", "_lang" : "en"}
@@ -8390,7 +8710,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30800/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Porthmeor", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30800/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30800/date/20160919/time/110000/recordDate/20160919", "name" : {"_value" : "Porthmeor", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthmeor", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30800", "easting" : 151590.0, "lat" : 50.2153000175372, "long" : -5.48338305416661, "name" : {"_value" : "Sampling point at Porthmeor", "_lang" : "en"}
@@ -8413,7 +8734,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-30900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/30900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30900/date/20160919/time/112000/recordDate/20160919", "name" : {"_value" : "Porthgwidden", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30900/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/30900/date/20160919/time/112000/recordDate/20160919", "name" : {"_value" : "Porthgwidden", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthgwidden", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/30900", "easting" : 152080.0, "lat" : 50.2172111971261, "long" : -5.47665213877545, "name" : {"_value" : "Sampling point at Porthgwidden", "_lang" : "en"}
@@ -8436,7 +8758,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-31000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31000/date/20160919/time/114000/recordDate/20160919", "name" : {"_value" : "Porthminster", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31000/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31000/date/20160919/time/114000/recordDate/20160919", "name" : {"_value" : "Porthminster", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthminster", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31000", "easting" : 152060.0, "lat" : 50.2086747709166, "long" : -5.47631146879273, "name" : {"_value" : "Sampling point at Porthminster", "_lang" : "en"}
@@ -8459,7 +8782,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-31100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31100/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31100/date/20160919/time/120300/recordDate/20160919", "name" : {"_value" : "Carbis Bay Station Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31100/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31100/date/20160919/time/120300/recordDate/20160919", "name" : {"_value" : "Carbis Bay Station Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/carbis-bay-station-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31100", "easting" : 152820.0, "lat" : 50.1987589771395, "long" : -5.46493862733191, "name" : {"_value" : "Sampling point at Carbis Bay Station Beach", "_lang" : "en"}
@@ -8482,7 +8806,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-31200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31200/date/20160919/time/101800/recordDate/20160919", "name" : {"_value" : "Carbis Bay Porth Kidney Sands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31200/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31200/date/20160919/time/101800/recordDate/20160919", "name" : {"_value" : "Carbis Bay Porth Kidney Sands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/carbis-bay-porth-kidney-sands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31200", "easting" : 154620.0, "lat" : 50.1941216239555, "long" : -5.43937723793687, "name" : {"_value" : "Sampling point at Carbis Bay Porth Kidney Sands", "_lang" : "en"}
@@ -8505,7 +8830,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-31300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31300/date/20160919/time/124000/recordDate/20160919", "name" : {"_value" : "The Towans (Hayle)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31300/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31300/date/20160919/time/124000/recordDate/20160919", "name" : {"_value" : "The Towans (Hayle)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/the-towans-hayle", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31300", "easting" : 156270.0, "lat" : 50.2047682940131, "long" : -5.41701497977548, "name" : {"_value" : "Sampling point at The Towans (Hayle)", "_lang" : "en"}
@@ -8528,7 +8854,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3105-31400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31400/date/20160919/time/131500/recordDate/20160919", "name" : {"_value" : "The Towans (Godrevy)", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31400/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31400/date/20160919/time/131500/recordDate/20160919", "name" : {"_value" : "The Towans (Godrevy)", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/the-towans-godrevy", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31400", "easting" : 158180.0, "lat" : 50.2279961593516, "long" : -5.39189088555596, "name" : {"_value" : "Sampling point at The Towans (Godrevy)", "_lang" : "en"}
@@ -8551,7 +8878,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3103-31500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-31500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31500/date/20160919/time/135000/recordDate/20160919", "name" : {"_value" : "Portreath", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-31500/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31500/date/20160919/time/135000/recordDate/20160919", "name" : {"_value" : "Portreath", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/portreath", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31500", "easting" : 165350.0, "lat" : 50.2612329369265, "long" : -5.29363312652798, "name" : {"_value" : "Sampling point at Portreath", "_lang" : "en"}
@@ -8574,7 +8902,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-31600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31600/date/20160919/time/141500/recordDate/20160919", "name" : {"_value" : "Porthtowan", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31600/date/20160919/time/141500/recordDate/20160919", "name" : {"_value" : "Porthtowan", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthtowan", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31600", "easting" : 169127.0, "lat" : 50.2875216194933, "long" : -5.24241622838034, "name" : {"_value" : "Sampling point at Porthtowan", "_lang" : "en"}
@@ -8597,7 +8926,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-31650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31650/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31650/date/20160919/time/144000/recordDate/20160919", "name" : {"_value" : "Chapel Porth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31650/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31650/date/20160919/time/144000/recordDate/20160919", "name" : {"_value" : "Chapel Porth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/chapel-porth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31650", "easting" : 169729.0, "lat" : 50.3004, "long" : -5.2348, "name" : {"_value" : "Sampling point at Chapel Porth", "_lang" : "en"}
@@ -8620,7 +8950,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-31700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31700/date/20160922/time/102500/recordDate/20160922", "name" : {"_value" : "Trevaunance Cove", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31700/date/20160922/time/102500/recordDate/20160922", "name" : {"_value" : "Trevaunance Cove", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/trevaunance-cove", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31700", "easting" : 172220.0, "lat" : 50.3204028346129, "long" : -5.2011963562627, "name" : {"_value" : "Sampling point at Trevaunance Cove", "_lang" : "en"}
@@ -8643,7 +8974,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-31800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31800/date/20160922/time/110000/recordDate/20160922", "name" : {"_value" : "Perranporth Village End", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31800/2017:1", "controllerName" : "Perranzabuloe"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31800/date/20160922/time/110000/recordDate/20160922", "name" : {"_value" : "Perranporth Village End", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/perranporth-village-end", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31800", "easting" : 175640.0, "lat" : 50.349372204644, "long" : -5.1550635763185, "name" : {"_value" : "Sampling point at Perranporth Village End", "_lang" : "en"}
@@ -8666,7 +8998,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-31900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/31900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31900/date/20160922/time/114000/recordDate/20160922", "name" : {"_value" : "Perranporth Penhale Sands", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31900/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/31900/date/20160922/time/114000/recordDate/20160922", "name" : {"_value" : "Perranporth Penhale Sands", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/perranporth-penhale-sands", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/31900", "easting" : 175950.0, "lat" : 50.3593678651711, "long" : -5.1513676068956, "name" : {"_value" : "Sampling point at Perranporth Penhale Sands", "_lang" : "en"}
@@ -8689,7 +9022,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3102-32000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-32000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32000/date/20160922/time/122000/recordDate/20160922", "name" : {"_value" : "Holywell Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-32000/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32000/date/20160922/time/122000/recordDate/20160922", "name" : {"_value" : "Holywell Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/holywell-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32000", "easting" : 176520.0, "lat" : 50.3919113546784, "long" : -5.1455057863139, "name" : {"_value" : "Sampling point at Holywell Bay", "_lang" : "en"}
@@ -8718,7 +9052,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-03-31T11:24:55", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-27T14:49:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/32100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32100/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/32100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8745,7 +9080,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32200/date/20160922/time/135900/recordDate/20160922", "name" : {"_value" : "Fistral", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32200/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32200/date/20160922/time/135900/recordDate/20160922", "name" : {"_value" : "Fistral", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/fistral", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32200", "easting" : 179980.0, "lat" : 50.4177321832166, "long" : -5.09850302983969, "name" : {"_value" : "Sampling point at Fistral", "_lang" : "en"}
@@ -8768,7 +9104,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32300/date/20160922/time/143500/recordDate/20160922", "name" : {"_value" : "Towan", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32300/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32300/date/20160922/time/143500/recordDate/20160922", "name" : {"_value" : "Towan", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/towan", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32300", "easting" : 180977.0, "lat" : 50.4182930793456, "long" : -5.08417872138159, "name" : {"_value" : "Sampling point at Towan", "_lang" : "en"}
@@ -8791,7 +9128,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32310", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32310/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32310/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32310/date/20160922/time/144500/recordDate/20160922", "name" : {"_value" : "Great Western", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32310/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32310/date/20160922/time/144500/recordDate/20160922", "name" : {"_value" : "Great Western", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/great-western", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32310", "easting" : 181530.0, "lat" : 50.415976061967, "long" : -5.07656644368544, "name" : {"_value" : "Sampling point at Great Western", "_lang" : "en"}
@@ -8814,7 +9152,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32320", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32320/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32320/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32320/date/20160922/time/145500/recordDate/20160922", "name" : {"_value" : "Tolcarne", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32320/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32320/date/20160922/time/145500/recordDate/20160922", "name" : {"_value" : "Tolcarne", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/tolcarne", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32320", "easting" : 181760.0, "lat" : 50.4176780168458, "long" : -5.07343859800726, "name" : {"_value" : "Sampling point at Tolcarne", "_lang" : "en"}
@@ -8837,7 +9176,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32330", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32330/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32330/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32330/date/20160922/time/150900/recordDate/20160922", "name" : {"_value" : "Lusty Glaze", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32330/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32330/date/20160922/time/150900/recordDate/20160922", "name" : {"_value" : "Lusty Glaze", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/lusty-glaze", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32330", "easting" : 182380.0, "lat" : 50.4217696277222, "long" : -5.06497385525916, "name" : {"_value" : "Sampling point at Lusty Glaze", "_lang" : "en"}
@@ -8860,7 +9200,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32340", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32340/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32340/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/32340/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32340/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/32340/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -8887,7 +9228,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32400/date/20160919/time/112500/recordDate/20160919", "name" : {"_value" : "Watergate Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32400/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32400/date/20160919/time/112500/recordDate/20160919", "name" : {"_value" : "Watergate Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/watergate-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32400", "easting" : 184070.0, "lat" : 50.4437670324647, "long" : -5.04258913278166, "name" : {"_value" : "Sampling point at Watergate Bay", "_lang" : "en"}
@@ -8910,7 +9252,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3106-32500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32500/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32500/date/20160919/time/120000/recordDate/20160919", "name" : {"_value" : "Mawgan Porth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32500/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32500/date/20160919/time/120000/recordDate/20160919", "name" : {"_value" : "Mawgan Porth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/mawgan-porth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32500", "easting" : 184830.0, "lat" : 50.4674853014895, "long" : -5.03340112417438, "name" : {"_value" : "Sampling point at Mawgan Porth", "_lang" : "en"}
@@ -8933,7 +9276,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-32550", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32550/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32550/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32550/date/20160919/time/124000/recordDate/20160919", "name" : {"_value" : "Porthcothan", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32550/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32550/date/20160919/time/124000/recordDate/20160919", "name" : {"_value" : "Porthcothan", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porthcothan", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32550", "easting" : 185720.0, "lat" : 50.5090318571474, "long" : -5.02351046811618, "name" : {"_value" : "Sampling point at Porthcothan", "_lang" : "en"}
@@ -8956,7 +9300,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-32600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32600/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32600/date/20160919/time/131000/recordDate/20160919", "name" : {"_value" : "Treyarnon Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32600/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32600/date/20160919/time/131000/recordDate/20160919", "name" : {"_value" : "Treyarnon Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/treyarnon-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32600", "easting" : 185860.0, "lat" : 50.5261459739228, "long" : -5.02262948465841, "name" : {"_value" : "Sampling point at Treyarnon Bay", "_lang" : "en"}
@@ -8979,7 +9324,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-32700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32700/date/20160919/time/134000/recordDate/20160919", "name" : {"_value" : "Constantine Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32700/date/20160919/time/134000/recordDate/20160919", "name" : {"_value" : "Constantine Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/constantine-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32700", "easting" : 185890.0, "lat" : 50.533251504212, "long" : -5.02266055940275, "name" : {"_value" : "Sampling point at Constantine Bay", "_lang" : "en"}
@@ -9002,7 +9348,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-32800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32800/date/20160919/time/140000/recordDate/20160919", "name" : {"_value" : "Mother Ivey`s Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32800/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32800/date/20160919/time/140000/recordDate/20160919", "name" : {"_value" : "Mother Ivey`s Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/mother-iveys-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32800", "easting" : 186450.0, "lat" : 50.5441430460904, "long" : -5.01545210516686, "name" : {"_value" : "Sampling point at Mother Ivey`s Bay", "_lang" : "en"}
@@ -9025,7 +9372,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-32900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/32900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32900/date/20160919/time/143000/recordDate/20160919", "name" : {"_value" : "Harlyn Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32900/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/32900/date/20160919/time/143000/recordDate/20160919", "name" : {"_value" : "Harlyn Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/harlyn-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/32900", "easting" : 187720.0, "lat" : 50.5402949099934, "long" : -4.99727977974794, "name" : {"_value" : "Sampling point at Harlyn Bay", "_lang" : "en"}
@@ -9048,7 +9396,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33000/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9075,7 +9424,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33200/date/20160923/time/100000/recordDate/20160923", "name" : {"_value" : "Daymer Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33200/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33200/date/20160923/time/100000/recordDate/20160923", "name" : {"_value" : "Daymer Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/daymer-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33200", "easting" : 192830.0, "lat" : 50.5613477998629, "long" : -4.92645433304806, "name" : {"_value" : "Sampling point at Daymer Bay", "_lang" : "en"}
@@ -9098,7 +9448,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33300/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9136,7 +9487,8 @@ http_interactions:
                 , "nirsRef" : "01451937", "som_recordDateTime" : {"_value" : "2017-04-12T09:37:47", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-06T16:18:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33350/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33350/date/20160923/time/113500/recordDate/20160923", "name" : {"_value" : "Trebarwith Strand", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33350/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33350/date/20160923/time/113500/recordDate/20160923", "name" : {"_value" : "Trebarwith Strand", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/trebarwith-strand", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33350", "easting" : 204850.0, "lat" : 50.6449814824378, "long" : -4.76160973193857, "name" : {"_value" : "Sampling point at Trebarwith Strand", "_lang" : "en"}
@@ -9159,7 +9511,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33360", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33360/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33360/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33360/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33360/2017:1", "controllerName" : "St. Gennys"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33360/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9186,7 +9539,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33400/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33400/date/20160923/time/124300/recordDate/20160923", "name" : {"_value" : "Widemouth Sand", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33400/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33400/date/20160923/time/124300/recordDate/20160923", "name" : {"_value" : "Widemouth Sand", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/widemouth-sand", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33400", "easting" : 219840.0, "lat" : 50.7931022337454, "long" : -4.55761549184591, "name" : {"_value" : "Sampling point at Widemouth Sand", "_lang" : "en"}
@@ -9209,7 +9563,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33500/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9236,7 +9591,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33600/2017:1", "controllerName" : "Cornwall"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/33600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9263,7 +9619,8 @@ http_interactions:
               , "eubwidNotation" : "ukk3104-33700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33700/date/20160923/time/142000/recordDate/20160923", "name" : {"_value" : "Bude Sandy Mouth", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33700/2017:1", "controllerName" : "Cornwall"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33700/date/20160923/time/142000/recordDate/20160923", "name" : {"_value" : "Bude Sandy Mouth", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/bude-sandy-mouth", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33700", "easting" : 220160.0, "lat" : 50.8609376590203, "long" : -4.55677993814878, "name" : {"_value" : "Sampling point at Bude Sandy Mouth", "_lang" : "en"}
@@ -9288,7 +9645,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4307-33800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4307-33800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33800/date/20160923/time/144000/recordDate/20160923", "name" : {"_value" : "Hartland Quay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4307-33800/2017:1", "controllerName" : "Torridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33800/date/20160923/time/144000/recordDate/20160923", "name" : {"_value" : "Hartland Quay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/hartland-quay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33800", "easting" : 222300.0, "lat" : 50.9955446624716, "long" : -4.53367543882316, "name" : {"_value" : "Sampling point at Hartland Quay", "_lang" : "en"}
@@ -9313,7 +9671,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4307-33900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/33900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4307-33900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33900/date/20160920/time/123500/recordDate/20160920", "name" : {"_value" : "Westward Ho!", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4307-33900/2017:1", "controllerName" : "Torridge"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/33900/date/20160920/time/123500/recordDate/20160920", "name" : {"_value" : "Westward Ho!", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/westward-ho!", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/33900", "easting" : 243338.0, "lat" : 51.0437749741397, "long" : -4.23616288248315, "name" : {"_value" : "Sampling point at Westward Ho!", "_lang" : "en"}
@@ -9338,7 +9697,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/4", "name" : {"_value" : "Poor", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34000/2017:1", "controllerName" : "Instow"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9367,7 +9727,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34100/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9396,7 +9757,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34200/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9425,7 +9787,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34300/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34300/date/20160920/time/103000/recordDate/20160920", "name" : {"_value" : "Putsborough", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34300/2017:1", "controllerName" : "North Devon"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34300/date/20160920/time/103000/recordDate/20160920", "name" : {"_value" : "Putsborough", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/putsborough", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/34300", "easting" : 244750.0, "lat" : 51.1458097096823, "long" : -4.22090410376103, "name" : {"_value" : "Sampling point at Putsborough", "_lang" : "en"}
@@ -9450,7 +9813,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34400/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9479,7 +9843,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34410", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34410/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34410/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34410/date/20160920/time/100000/recordDate/20160920", "name" : {"_value" : "Combesgate Beach, Woolacombe", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34410/2017:1", "controllerName" : "Mortehoe"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34410/date/20160920/time/100000/recordDate/20160920", "name" : {"_value" : "Combesgate Beach, Woolacombe", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/combesgate-beach-woolacombe", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/34410", "easting" : 245450.0, "lat" : 51.1782564135866, "long" : -4.21244811030368, "name" : {"_value" : "Sampling point at Combesgate Beach, Woolacombe", "_lang" : "en"}
@@ -9504,7 +9869,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34450", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34450/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34450/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34450/date/20160916/time/103000/recordDate/20160916", "name" : {"_value" : "Ilfracombe Tunnels Beach", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34450/2017:1", "controllerName" : "North Devon"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34450/date/20160916/time/103000/recordDate/20160916", "name" : {"_value" : "Ilfracombe Tunnels Beach", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/ilfracombe-tunnels-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/34450", "easting" : 251508.0, "lat" : 51.210459434379, "long" : -4.12725441460376, "name" : {"_value" : "Sampling point at Ilfracombe Tunnels Beach", "_lang" : "en"}
@@ -9529,7 +9895,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/4", "name" : {"_value" : "Poor", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34500/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9558,7 +9925,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34600/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9598,7 +9966,8 @@ http_interactions:
                 , "nirsRef" : "01411946", "som_recordDateTime" : {"_value" : "2017-04-06T16:17:09", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-06T16:08:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34700/2017:1", "controllerName" : "Combe Martin"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9627,7 +9996,8 @@ http_interactions:
               , "eubwidNotation" : "ukk4304-34800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk4304-34800/2017:1", "controllerName" : "North Devon"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/34800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9656,7 +10026,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2305-34900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/34900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-34900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34900/date/20160921/time/103400/recordDate/20160921", "name" : {"_value" : "Porlock Weir", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-34900/2017:1", "controllerName" : "West Somerset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/34900/date/20160921/time/103400/recordDate/20160921", "name" : {"_value" : "Porlock Weir", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/porlock-weir", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/34900", "easting" : 286521.0, "lat" : 51.2190192938815, "long" : -3.6262649577776, "name" : {"_value" : "Sampling point at Porlock Weir", "_lang" : "en"}
@@ -9681,7 +10052,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2305-35000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35000/2017:1", "controllerName" : "West Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9710,7 +10082,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2305-35100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35100/2017:1", "controllerName" : "West Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9744,7 +10117,8 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-08-03T11:53:50", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-08-03T11:50:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35200/2017:1", "controllerName" : "West Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9782,7 +10156,8 @@ http_interactions:
                 , "nirsRef" : "07000000", "som_recordDateTime" : {"_value" : "2017-04-06T13:38:07", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-06T13:37:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35300/2017:1", "controllerName" : "Sedgemoor"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9811,7 +10186,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2302-35500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35500/2017:1", "controllerName" : "Sedgemoor"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9840,7 +10216,8 @@ http_interactions:
               , "eubwidNotation" : "ukk2302-35600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35600/2017:1", "controllerName" : "Sedgemoor"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9867,7 +10244,8 @@ http_interactions:
               , "eubwidNotation" : "ukk1202-35700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35700/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35700/2017:1", "controllerName" : "North Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35700/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9894,7 +10272,8 @@ http_interactions:
               , "eubwidNotation" : "ukk1202-35800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/35800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35800/2017:1", "controllerName" : "North Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/35800/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9927,7 +10306,8 @@ http_interactions:
                 , "nirsRef" : "12341000", "som_recordDateTime" : {"_value" : "2017-08-03T09:22:01", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-23T16:42:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/35900/date/20160922/time/104500/recordDate/20160922", "name" : {"_value" : "Weston-super-Mare Sand Bay", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35900/2017:1", "controllerName" : "North Somerset"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/35900/date/20160922/time/104500/recordDate/20160922", "name" : {"_value" : "Weston-super-Mare Sand Bay", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/weston-super-mare-sand-bay", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/35900", "easting" : 332838.0, "lat" : 51.3644875606138, "long" : -2.96609706624921, "name" : {"_value" : "Sampling point at Weston-super-Mare Sand Bay", "_lang" : "en"}
@@ -9950,7 +10330,8 @@ http_interactions:
               , "eubwidNotation" : "ukk1202-36000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/36000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/36000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1", "controllerName" : "North Somerset"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/36000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -9977,7 +10358,8 @@ http_interactions:
               , "eubwidNotation" : "ukk1100-36050", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/36050/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1100-36050/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/36050/date/20160922/time/091500/recordDate/20160922", "name" : {"_value" : "Henleaze Lake", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1100-36050/2017:1", "controllerName" : "City of Bristol"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/36050/date/20160922/time/091500/recordDate/20160922", "name" : {"_value" : "Henleaze Lake", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/henleaze-lake", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/36050", "easting" : 358047.0, "lat" : 51.4946241931076, "long" : -2.60570469108093, "name" : {"_value" : "Sampling point at Henleaze Lake", "_lang" : "en"}
@@ -10000,7 +10382,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5400-40750", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/40750/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40750/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/40750/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40750/2017:1", "controllerName" : "Wirral"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/40750/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10027,7 +10410,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5400-40800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/40800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40800/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/40800/date/20160923/time/155000/recordDate/20160923", "name" : {"_value" : "Meols", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40800/2017:1", "controllerName" : "Wirral"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/40800/date/20160923/time/155000/recordDate/20160923", "name" : {"_value" : "Meols", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/meols", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/40800", "easting" : 323000.0, "lat" : 53.4065842825349, "long" : -3.15974278713184, "name" : {"_value" : "Sampling point at Meols", "_lang" : "en"}
@@ -10050,7 +10434,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5400-40900", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/40900/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40900/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/40900/date/20160923/time/144000/recordDate/20160923", "name" : {"_value" : "Moreton", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-40900/2017:1", "controllerName" : "Wirral"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/40900/date/20160923/time/144000/recordDate/20160923", "name" : {"_value" : "Moreton", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/moreton", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/40900", "easting" : 325700.0, "lat" : 53.417756050842, "long" : -3.11942028040805, "name" : {"_value" : "Sampling point at Moreton", "_lang" : "en"}
@@ -10073,7 +10458,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5400-41000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/41000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-41000/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/41000/date/20160923/time/152000/recordDate/20160923", "name" : {"_value" : "Wallasey", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5400-41000/2017:1", "controllerName" : "Wirral"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/41000/date/20160923/time/152000/recordDate/20160923", "name" : {"_value" : "Wallasey", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/wallasey", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/41000", "easting" : 328526.0, "lat" : 53.4335785280341, "long" : -3.07728292148699, "name" : {"_value" : "Sampling point at Wallasey", "_lang" : "en"}
@@ -10096,7 +10482,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5300-41200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/41200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/41200/date/20160916/time/122000/recordDate/20160916", "name" : {"_value" : "Formby", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41200/2017:1", "controllerName" : "Sefton"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/41200/date/20160916/time/122000/recordDate/20160916", "name" : {"_value" : "Formby", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/formby", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/41200", "easting" : 326800.0, "lat" : 53.5482180476627, "long" : -3.10625887520372, "name" : {"_value" : "Sampling point at Formby", "_lang" : "en"}
@@ -10119,7 +10506,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5300-41300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/41300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41300/2017:1", "controllerName" : "Sefton"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10146,7 +10534,8 @@ http_interactions:
               , "eubwidNotation" : "ukd5300-41500", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/41500/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd5300-41500/2017:1", "controllerName" : "Sefton"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10181,7 +10570,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4303-41800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4303-41800/2017:1", "controllerName" : "Fylde"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10216,7 +10606,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4303-41900/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4303-41900/2017:1", "controllerName" : "Fylde"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/41900/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10249,7 +10640,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42100/2017:1", "controllerName" : "Blackpool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10282,7 +10674,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42300/2017:1", "controllerName" : "Blackpool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10315,7 +10708,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42500/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42500/2017:1", "controllerName" : "Blackpool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42500/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10348,7 +10742,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4200-42600/2017:1", "controllerName" : "Blackpool"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42600/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10383,7 +10778,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4312-42800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4312-42800/2017:1", "controllerName" : "Wyre"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/42800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10418,7 +10814,8 @@ http_interactions:
                 , "nirsRef" : "01978563", "som_recordDateTime" : {"_value" : "2017-04-05T13:35:21", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-05T13:33:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4312-43000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4312-43000/2017:1", "controllerName" : "Wyre"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10447,7 +10844,8 @@ http_interactions:
               , "eubwidNotation" : "ukd4305-43260", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/43260/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4305-43260/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43260/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4305-43260/2017:1", "controllerName" : "Lancaster"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43260/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/increased", "name" : {"_value" : "increased", "_lang" : "en"}
                 }
               }
@@ -10476,7 +10874,8 @@ http_interactions:
               , "eubwidNotation" : "ukd4305-43550", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/43550/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4305-43550/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43550/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd4305-43550/2017:1", "controllerName" : "Lancaster"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/43550/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/increased", "name" : {"_value" : "increased", "_lang" : "en"}
                 }
               }
@@ -10505,7 +10904,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1102-44200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/44200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44200/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44200/2017:1", "controllerName" : "Barrow-in-Furness"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44200/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10534,7 +10934,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1102-44300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/44300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44300/2017:1", "controllerName" : "Barrow-in-Furness"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10563,7 +10964,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1102-44400", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/44400/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44400/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1102-44400/2017:1", "controllerName" : "Barrow-in-Furness"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44400/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10592,7 +10994,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1103-44800", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/44800/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-44800/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-44800/2017:1", "controllerName" : "Copeland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/44800/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10621,7 +11024,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1103-45200", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45200/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45200/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45200/date/20160921/time/123300/recordDate/20160921", "name" : {"_value" : "Silecroft", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45200/2017:1", "controllerName" : "Copeland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45200/date/20160921/time/123300/recordDate/20160921", "name" : {"_value" : "Silecroft", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/silecroft", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/45200", "easting" : 312000.0, "lat" : 54.218947055813, "long" : -3.35110251563719, "name" : {"_value" : "Sampling point at Silecroft", "_lang" : "en"}
@@ -10646,7 +11050,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1103-45600", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45600/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45600/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/45600/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45600/2017:1", "controllerName" : "Copeland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/45600/date/20141002-083021", "expiresAt" : {"_value" : "2014-10-03T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10675,7 +11080,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1203-45625", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45625/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45625/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45625/date/20160921/time/120000/recordDate/20160921", "name" : {"_value" : "Windermere, Lakeside YMCA", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45625/2017:1", "controllerName" : "South Lakeland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45625/date/20160921/time/120000/recordDate/20160921", "name" : {"_value" : "Windermere, Lakeside YMCA", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/windermere-lakeside-ymca", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/45625", "easting" : 337528.0, "lat" : 54.3003949508162, "long" : -2.9614629622469, "name" : {"_value" : "Sampling point at Windermere, Lakeside YMCA", "_lang" : "en"}
@@ -10700,7 +11106,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1203-45650", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45650/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45650/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45650/date/20160921/time/125500/recordDate/20160921", "name" : {"_value" : "Windermere, Millerground Landing", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45650/2017:1", "controllerName" : "South Lakeland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45650/date/20160921/time/125500/recordDate/20160921", "name" : {"_value" : "Windermere, Millerground Landing", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/windermere-millerground-landing", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/45650", "easting" : 340178.0, "lat" : 54.3807, "long" : -2.9225, "name" : {"_value" : "Sampling point at Windermere, Millerground Landing", "_lang" : "en"}
@@ -10725,7 +11132,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1203-45675", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45675/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45675/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45675/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Windermere, Rayrigg Meadow", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45675/2017:1", "controllerName" : "South Lakeland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45675/date/20160921/time/125000/recordDate/20160921", "name" : {"_value" : "Windermere, Rayrigg Meadow", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/windermere-rayrigg-meadow", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/45675", "easting" : 340177.0, "lat" : 54.3781537315643, "long" : -2.92249644240972, "name" : {"_value" : "Sampling point at Windermere, Rayrigg Meadow", "_lang" : "en"}
@@ -10750,7 +11158,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1203-45700", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45700/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45700/2017:1", "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45700/date/20160921/time/121500/recordDate/20160921", "name" : {"_value" : "Windermere, Fellfoot", "_lang" : "en"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1203-45700/2017:1", "controllerName" : "South Lakeland"}
+              , "latestSampleAssessment" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/45700/date/20160921/time/121500/recordDate/20160921", "name" : {"_value" : "Windermere, Fellfoot", "_lang" : "en"}
               , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/north-west-north-west-office", "name" : {"_value" : "North West", "_lang" : "en"}
               }
               , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/windermere-fellfoot", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/45700", "easting" : 337990.0, "lat" : 54.274516938995, "long" : -2.95378173858218, "name" : {"_value" : "Sampling point at Windermere, Fellfoot", "_lang" : "en"}
@@ -10775,7 +11184,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1103-45920", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/45920/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/1", "name" : {"_value" : "Excellent", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45920/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/45920/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1103-45920/2017:1", "controllerName" : "Copeland"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/45920/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/increased", "name" : {"_value" : "increased", "_lang" : "en"}
                 }
               }
@@ -10804,7 +11214,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1101-46000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/46000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46000/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46000/2017:1", "controllerName" : "Allerdale"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46000/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10833,7 +11244,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1101-46100", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/46100/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46100/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46100/2017:1", "controllerName" : "Allerdale"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46100/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/increased", "name" : {"_value" : "increased", "_lang" : "en"}
                 }
               }
@@ -10862,7 +11274,8 @@ http_interactions:
               , "eubwidNotation" : "ukd1101-46300", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/46300/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/3", "name" : {"_value" : "Sufficient", "_lang" : "en"}
                 }
               }
-              , "latestProfile" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46300/2017:1", "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukd1101-46300/2017:1", "controllerName" : "Allerdale"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/46300/date/20171006-144034", "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
                 , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
                 }
               }
@@ -10879,5 +11292,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:52 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/bathing_waters_api.yml
+++ b/test/fixtures/vcr_cassettes/bathing_waters_api.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:26:43 GMT
+      - Fri, 02 Feb 2018 21:36:36 GMT
       Etag:
       - '"ccc788b3d2ae89ab-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:29:41 GMT
+      - Fri, 02 Feb 2018 21:39:35 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '144'
+      - '161'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -11292,5 +11292,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:26:43 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:36 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/preview_page_test_1.yml
+++ b/test/fixtures/vcr_cassettes/preview_page_test_1.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:59 GMT
+      - Fri, 02 Feb 2018 17:21:32 GMT
       Etag:
       - '"66c45651a96b9d84-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:59 GMT
+      - Fri, 02 Feb 2018 17:24:32 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '122'
-      Content-Length:
-      - '1693'
+      - '143'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -88,5 +88,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:40:00 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:33 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/preview_page_test_1.yml
+++ b/test/fixtures/vcr_cassettes/preview_page_test_1.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:13 GMT
+      - Fri, 02 Feb 2018 15:39:59 GMT
       Etag:
       - '"66c45651a96b9d84-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:13 GMT
+      - Fri, 02 Feb 2018 15:42:59 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '37'
-      Transfer-Encoding:
-      - chunked
+      - '122'
+      Content-Length:
+      - '1693'
       Connection:
       - keep-alive
     body:
@@ -88,5 +88,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:13 GMT
+  recorded_at: Fri, 02 Feb 2018 15:40:00 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
+++ b/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
@@ -20,24 +20,26 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
+      Age:
+      - '2'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:25 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:28 GMT
+      - Fri, 02 Feb 2018 21:39:23 GMT
       Server:
-      - Server
+      - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '135'
-      Transfer-Encoding:
-      - chunked
+      - '152'
+      Content-Length:
+      - '57852'
       Connection:
       - keep-alive
     body:
@@ -10877,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
+++ b/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&country=http://data.ordnancesurvey.co.uk/id/country/england
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600
     body:
       encoding: US-ASCII
       string: ''
@@ -21,31 +21,31 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '2'
+      - '3'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:16 GMT
+      - Fri, 02 Feb 2018 15:39:51 GMT
       Etag:
-      - '"fa2d5bebcad82a90-gzip"'
+      - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:14 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '38'
+      - '114'
       Content-Length:
-      - '57892'
+      - '57852'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
@@ -10879,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:51 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
+++ b/test/fixtures/vcr_cassettes/test_all_bathing_waters.yml
@@ -20,26 +20,24 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '3'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:51 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:28 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
-      Content-Length:
-      - '57852'
+      - '135'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10877,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:51 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_annual_compliance.yml
+++ b/test/fixtures/vcr_cassettes/test_annual_compliance.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 17:21:31 GMT
       Etag:
       - '"c1d271b3596a8a9-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 16:39:49 GMT
+      - Fri, 02 Feb 2018 18:21:31 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '116'
-      Transfer-Encoding:
-      - chunked
+      - '140'
+      Content-Length:
+      - '1118'
       Connection:
       - keep-alive
     body:
@@ -92,5 +92,5 @@ http_interactions:
             ], "itemsPerPage" : 3, "next" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water-quality/compliance-rBWD/bathing-water/ukc2102-03600.json?_pageSize=3&_page=1&_sort=-sampleYear.ordinalYear", "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_annual_compliance.yml
+++ b/test/fixtures/vcr_cassettes/test_annual_compliance.yml
@@ -20,26 +20,24 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '3270'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water-quality/compliance-rBWD/bathing-water/ukc2102-03600.json?_pageSize=3&_sort=-sampleYear.ordinalYear
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:49 GMT
       Etag:
       - '"c1d271b3596a8a9-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:25:45 GMT
+      - Fri, 02 Feb 2018 16:39:49 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '28'
-      Content-Length:
-      - '1124'
+      - '116'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -94,5 +92,5 @@ http_interactions:
             ], "itemsPerPage" : 3, "next" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water-quality/compliance-rBWD/bathing-water/ukc2102-03600.json?_pageSize=3&_page=1&_sort=-sampleYear.ordinalYear", "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:15 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_annual_compliance.yml
+++ b/test/fixtures/vcr_cassettes/test_annual_compliance.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:31 GMT
+      - Fri, 02 Feb 2018 21:36:25 GMT
       Etag:
       - '"c1d271b3596a8a9-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 18:21:31 GMT
+      - Fri, 02 Feb 2018 22:36:26 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '140'
-      Content-Length:
-      - '1118'
+      - '158'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -92,5 +92,5 @@ http_interactions:
             ], "itemsPerPage" : 3, "next" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water-quality/compliance-rBWD/bathing-water/ukc2102-03600.json?_pageSize=3&_page=1&_sort=-sampleYear.ordinalYear", "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:26 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water.yml
@@ -27,17 +27,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:18 GMT
+      - Fri, 02 Feb 2018 15:39:47 GMT
       Etag:
       - '"5499bb600cb7b0b2-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:17 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
       - nginx
       Vary:
       - Accept-Encoding
       X-Response-Id:
-      - '62807'
+      - '72435'
       Content-Length:
       - '1228'
       Connection:
@@ -87,5 +87,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:18 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:47 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water.yml
@@ -27,17 +27,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:47 GMT
+      - Fri, 02 Feb 2018 17:21:32 GMT
       Etag:
       - '"5499bb600cb7b0b2-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:32 GMT
       Server:
       - nginx
       Vary:
       - Accept-Encoding
       X-Response-Id:
-      - '72435'
+      - '73217'
       Content-Length:
       - '1228'
       Connection:
@@ -87,5 +87,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:47 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water.yml
@@ -27,17 +27,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:32 GMT
+      - Fri, 02 Feb 2018 21:36:34 GMT
       Etag:
       - '"5499bb600cb7b0b2-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:32 GMT
+      - Fri, 02 Feb 2018 21:39:34 GMT
       Server:
       - nginx
       Vary:
       - Accept-Encoding
       X-Response-Id:
-      - '73217'
+      - '74208'
       Content-Length:
       - '1228'
       Connection:
@@ -87,5 +87,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:35 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
@@ -20,22 +20,24 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
+      Age:
+      - '2'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:47 GMT
+      - Fri, 02 Feb 2018 17:21:32 GMT
       Etag:
       - '"d36405e5b567ec1f-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:31 GMT
       Server:
-      - Server
+      - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '113'
+      - '138'
       Content-Length:
       - '1660'
       Connection:
@@ -88,5 +90,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:47 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
     body:
       encoding: US-ASCII
       string: ''
@@ -23,29 +23,29 @@ http_interactions:
       Age:
       - '2'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:32 GMT
+      - Fri, 02 Feb 2018 21:36:26 GMT
       Etag:
-      - '"d36405e5b567ec1f-gzip"'
+      - '"8b2a04a1746e23a3-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:31 GMT
+      - Fri, 02 Feb 2018 21:39:25 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '138'
+      - '156'
       Content-Length:
-      - '1660'
+      - '1685'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
               }
@@ -59,7 +59,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "controllerName" : "Northumberland", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukc2102-03600_1-webres.jpg"}
@@ -90,5 +90,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:26 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_1.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:47 GMT
       Etag:
       - '"d36405e5b567ec1f-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:16 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '41'
-      Transfer-Encoding:
-      - chunked
+      - '113'
+      Content-Length:
+      - '1660'
       Connection:
       - keep-alive
     body:
@@ -88,5 +88,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:47 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
@@ -21,25 +21,25 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '1'
+      - '3'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:26 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:28 GMT
+      - Fri, 02 Feb 2018 21:39:23 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '135'
+      - '152'
       Content-Length:
-      - '58274'
+      - '57852'
       Connection:
       - keep-alive
     body:
@@ -10879,10 +10879,10 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:26 GMT
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
     body:
       encoding: US-ASCII
       string: ''
@@ -10901,29 +10901,29 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:26 GMT
       Etag:
-      - '"578a1ba60e56084e-gzip"'
+      - '"2773cbb646aa9f79-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:30 GMT
+      - Fri, 02 Feb 2018 21:39:26 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '136'
+      - '159'
       Content-Length:
-      - '1705'
+      - '1725'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk2204-19900", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366648", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366648", "label" : [{"_value" : "Companies House profile for Wessex Water Services Limited", "_lang" : "en"}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk2204-19900", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366648", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366648", "label" : [{"_value" : "Companies House profile for Wessex Water Services Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Wessex Water Services Limited", "_lang" : "en"}
               }
@@ -10939,7 +10939,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19900/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2204-19900/2017:1", "controllerName" : "Purbeck", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2204-19900_1-webres.jpg"}
@@ -10970,5 +10970,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:26 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&country=http://data.ordnancesurvey.co.uk/id/country/england
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600
     body:
       encoding: US-ASCII
       string: ''
@@ -23,29 +23,29 @@ http_interactions:
       Age:
       - '2'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Etag:
-      - '"fa2d5bebcad82a90-gzip"'
+      - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:14 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '38'
+      - '114'
       Content-Length:
-      - '57892'
+      - '57852'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
@@ -10879,7 +10879,7 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
 - request:
     method: get
     uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
@@ -10905,19 +10905,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Etag:
       - '"578a1ba60e56084e-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:16 GMT
+      - Fri, 02 Feb 2018 15:42:50 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '39'
-      Transfer-Encoding:
-      - chunked
+      - '119'
+      Content-Length:
+      - '1705'
       Connection:
       - keep-alive
     body:
@@ -10970,5 +10970,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_water_by_id_2.yml
@@ -21,25 +21,25 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '2'
+      - '1'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:28 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
+      - '135'
       Content-Length:
-      - '57852'
+      - '58274'
       Connection:
       - keep-alive
     body:
@@ -10879,7 +10879,7 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
 - request:
     method: get
     uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk2204-19900?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
@@ -10905,17 +10905,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Etag:
       - '"578a1ba60e56084e-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:50 GMT
+      - Fri, 02 Feb 2018 17:24:30 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '119'
+      - '136'
       Content-Length:
       - '1705'
       Connection:
@@ -10970,5 +10970,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&country=http://data.ordnancesurvey.co.uk/id/country/england
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600
     body:
       encoding: US-ASCII
       string: ''
@@ -20,32 +20,30 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '2'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:16 GMT
+      - Fri, 02 Feb 2018 15:39:49 GMT
       Etag:
-      - '"fa2d5bebcad82a90-gzip"'
+      - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:14 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '38'
-      Content-Length:
-      - '57892'
+      - '114'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
@@ -10879,5 +10877,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
@@ -20,24 +20,26 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
+      Age:
+      - '2'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:28 GMT
       Server:
-      - Server
+      - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
-      Transfer-Encoding:
-      - chunked
+      - '135'
+      Content-Length:
+      - '58274'
       Connection:
       - keep-alive
     body:
@@ -10877,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
+++ b/test/fixtures/vcr_cassettes/test_bathing_waters_each.yml
@@ -20,26 +20,24 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '2'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:24 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:28 GMT
+      - Fri, 02 Feb 2018 21:39:23 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '135'
-      Content-Length:
-      - '58274'
+      - '152'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10877,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:30 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:24 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:17 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Expires:
-      - Wed, 31 Jan 2018 17:20:17 GMT
+      - Fri, 02 Feb 2018 16:39:50 GMT
       Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Server:
       - Server
       X-Response-Id:
-      - '43'
+      - '118'
       Content-Length:
       - '0'
       Connection:
@@ -42,7 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:17 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
 - request:
     method: get
     uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
@@ -64,25 +64,25 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '2'
+      - '3'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:17 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Etag:
       - '"d36405e5b567ec1f-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:16 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '41'
+      - '113'
       Content-Length:
-      - '1667'
+      - '1660'
       Connection:
       - keep-alive
     body:
@@ -133,5 +133,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:17 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Expires:
-      - Fri, 02 Feb 2018 16:39:50 GMT
+      - Fri, 02 Feb 2018 18:21:31 GMT
       Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Server:
       - Server
       X-Response-Id:
-      - '118'
+      - '137'
       Content-Length:
       - '0'
       Connection:
@@ -42,7 +42,7 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
 - request:
     method: get
     uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
@@ -63,24 +63,22 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
-      Age:
-      - '3'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:30 GMT
       Etag:
       - '"d36405e5b567ec1f-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:31 GMT
       Server:
-      - Apache
+      - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '113'
+      - '138'
       Content-Length:
       - '1660'
       Connection:
@@ -133,5 +131,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
+++ b/test/fixtures/vcr_cassettes/test_bw_by_uri_1.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/id/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
+    uri: http://ea-rbwd-staging.epimorphics.net/id/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
     body:
       encoding: US-ASCII
       string: ''
@@ -25,15 +25,15 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:24 GMT
       Expires:
-      - Fri, 02 Feb 2018 18:21:31 GMT
+      - Fri, 02 Feb 2018 22:36:25 GMT
       Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Server:
       - Server
       X-Response-Id:
-      - '137'
+      - '155'
       Content-Length:
       - '0'
       Connection:
@@ -42,10 +42,10 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
     body:
       encoding: US-ASCII
       string: ''
@@ -64,29 +64,29 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:30 GMT
+      - Fri, 02 Feb 2018 21:36:24 GMT
       Etag:
-      - '"d36405e5b567ec1f-gzip"'
+      - '"8b2a04a1746e23a3-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:31 GMT
+      - Fri, 02 Feb 2018 21:39:25 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '138'
-      Content-Length:
-      - '1660'
+      - '156'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukc2102-03600.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
               }
@@ -100,7 +100,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukc2102-03600/2017:1", "controllerName" : "Northumberland", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukc2102-03600_1-webres.jpg"}
@@ -131,5 +131,5 @@ http_interactions:
             , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bw_by_uri_2.yml
+++ b/test/fixtures/vcr_cassettes/test_bw_by_uri_2.yml
@@ -27,19 +27,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:31 GMT
+      - Fri, 02 Feb 2018 21:36:25 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:28 GMT
+      - Fri, 02 Feb 2018 21:39:23 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '135'
+      - '152'
       Content-Length:
-      - '58274'
+      - '57852'
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bw_by_uri_2.yml
+++ b/test/fixtures/vcr_cassettes/test_bw_by_uri_2.yml
@@ -21,25 +21,25 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '1'
+      - '2'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 17:21:31 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:28 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
+      - '135'
       Content-Length:
-      - '57852'
+      - '58274'
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_county.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_county.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 17:21:31 GMT
       Etag:
       - '"7bb59e0b31dda1ec-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:49 GMT
+      - Fri, 02 Feb 2018 17:24:32 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '115'
+      - '142'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -359,5 +359,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_county.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_county.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:17 GMT
+      - Fri, 02 Feb 2018 15:39:49 GMT
       Etag:
       - '"7bb59e0b31dda1ec-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:17 GMT
+      - Fri, 02 Feb 2018 15:42:49 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '42'
+      - '115'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -359,5 +359,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:17 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_county.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_county.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&county.name=Somerset
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&county.name=Somerset
     body:
       encoding: US-ASCII
       string: ''
@@ -21,21 +21,21 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:31 GMT
+      - Fri, 02 Feb 2018 21:36:24 GMT
       Etag:
-      - '"7bb59e0b31dda1ec-gzip"'
+      - '"fd8c888924df9232-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:32 GMT
+      - Fri, 02 Feb 2018 21:39:24 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '142'
+      - '153'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -43,7 +43,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&county.name=Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk2305-34900", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366648", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366648", "label" : [{"_value" : "Companies House profile for Wessex Water Services Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Wessex Water Services Limited", "_lang" : "en"}
@@ -60,7 +60,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-34900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-34900/2017:1", "controllerName" : "West Somerset", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2305-34900_1-webres.jpg"}
@@ -94,7 +94,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35000/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35000/2017:1", "controllerName" : "West Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2305-35000_1-webres.jpg"}
@@ -138,7 +138,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35100/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35100/2017:1", "controllerName" : "West Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2305-35100_1-webres.jpg"}
@@ -187,7 +187,7 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-08-03T11:53:50", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-08-03T11:50:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35200/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2305-35200/2017:1", "controllerName" : "West Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2305-35200_1-webres.jpg"}
@@ -240,7 +240,7 @@ http_interactions:
                 , "nirsRef" : "07000000", "som_recordDateTime" : {"_value" : "2017-04-06T13:38:07", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-06T13:37:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35300/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35300/2017:1", "controllerName" : "Sedgemoor", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2302-35300_1-webres.jpg"}
@@ -284,7 +284,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35500/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35500/2017:1", "controllerName" : "Sedgemoor", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2302-35500_1-webres.jpg"}
@@ -328,7 +328,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35600/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk2302-35600/2017:1", "controllerName" : "Sedgemoor", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk2302-35600_1-webres.jpg"}
@@ -359,5 +359,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:24 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&district.name=North%20Somerset
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&district.name=North%20Somerset
     body:
       encoding: US-ASCII
       string: ''
@@ -21,29 +21,29 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:31 GMT
+      - Fri, 02 Feb 2018 21:36:25 GMT
       Etag:
-      - '"8f9679a4d9ddd00-gzip"'
+      - '"d3e57e00ed22d881-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:31 GMT
+      - Fri, 02 Feb 2018 21:39:25 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '141'
-      Transfer-Encoding:
-      - chunked
+      - '157'
+      Content-Length:
+      - '2682'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_page=0&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_page=0&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district.name=North+Somerset&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk1202-35700", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366648", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366648", "label" : [{"_value" : "Companies House profile for Wessex Water Services Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Wessex Water Services Limited", "_lang" : "en"}
@@ -58,7 +58,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35700/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35700/2017:1", "controllerName" : "North Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk1202-35700_1-webres.jpg"}
@@ -100,7 +100,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35800/2017:1", "controllerName" : "North Somerset", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk1202-35800_1-webres.jpg"}
@@ -148,7 +148,7 @@ http_interactions:
                 , "nirsRef" : "12341000", "som_recordDateTime" : {"_value" : "2017-08-03T09:22:01", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-23T16:42:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-35900/2017:1", "controllerName" : "North Somerset", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk1202-35900_1-webres.jpg"}
@@ -180,7 +180,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1", "controllerName" : "North Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk1202-36000_1-webres.jpg"}
@@ -211,5 +211,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Etag:
       - '"8f9679a4d9ddd00-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:16 GMT
+      - Fri, 02 Feb 2018 15:42:50 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '40'
+      - '117'
       Content-Length:
       - '2663'
       Connection:
@@ -211,5 +211,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:16 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district.yml
@@ -25,19 +25,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:31 GMT
       Etag:
       - '"8f9679a4d9ddd00-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:50 GMT
+      - Fri, 02 Feb 2018 17:24:31 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '117'
-      Content-Length:
-      - '2663'
+      - '141'
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
     body:
@@ -211,5 +211,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:50 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:17 GMT
+      - Fri, 02 Feb 2018 15:39:50 GMT
       Etag:
       - '"e94ae3b58808301d-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:17 GMT
+      - Fri, 02 Feb 2018 15:42:50 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '44'
+      - '120'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -2894,5 +2894,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:17 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:51 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
@@ -25,17 +25,17 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:50 GMT
+      - Fri, 02 Feb 2018 17:21:31 GMT
       Etag:
       - '"e94ae3b58808301d-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:50 GMT
+      - Fri, 02 Feb 2018 17:24:31 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '120'
+      - '139'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -2894,5 +2894,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:51 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
+++ b/test/fixtures/vcr_cassettes/test_bws_in_district_uri.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&district=http://statistics.data.gov.uk/id/statistical-geography/E06000052
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*&district=http://statistics.data.gov.uk/id/statistical-geography/E06000052
     body:
       encoding: US-ASCII
       string: ''
@@ -21,21 +21,21 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:31 GMT
+      - Fri, 02 Feb 2018 21:36:24 GMT
       Etag:
-      - '"e94ae3b58808301d-gzip"'
+      - '"86bbe5abfdc69417-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:31 GMT
+      - Fri, 02 Feb 2018 21:39:24 GMT
       Server:
       - Server
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '139'
+      - '154'
       Transfer-Encoding:
       - chunked
       Connection:
@@ -43,7 +43,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&district=http%3A%2F%2Fstatistics.data.gov.uk%2Fid%2Fstatistical-geography%2FE06000052&_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk3101-26520", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366665", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366665", "label" : [{"_value" : "Companies House profile for South West Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "South West Water Limited", "_lang" : "en"}
@@ -58,7 +58,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26520/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26520/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26520_1-webres.jpg"}
@@ -90,7 +90,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26530/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26530/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26530_1-webres.jpg"}
@@ -122,7 +122,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26570/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26570/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26570_1-webres.jpg"}
               , "latestSampleAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/26570/date/20150817/time/142500/recordDate/20150817", "escherichiaColiCount" : 10, "intestinalEnterococciCount" : 10, "sampleDateTime" : {"_about" : "http://reference.data.gov.uk/id/gregorian-instant/2015-08-17T14:25:00", "inXSDDateTime" : {"_value" : "2015-08-17T14:25:00", "_datatype" : "dateTime"}
                 }
@@ -152,7 +152,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26600_1-webres.jpg"}
@@ -184,7 +184,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26700_1-webres.jpg"}
@@ -216,7 +216,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26800/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26800_1-webres.jpg"}
@@ -258,7 +258,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26900/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-26900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-26900_1-webres.jpg"}
@@ -300,7 +300,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-27000/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3101-27000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3101-27000_1-webres.jpg"}
@@ -342,7 +342,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27100/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27100_1-webres.jpg"}
@@ -384,7 +384,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27200/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27200_1-webres.jpg"}
@@ -426,7 +426,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27300/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27300_1-webres.jpg"}
@@ -468,7 +468,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27400/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27400_1-webres.jpg"}
@@ -510,7 +510,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27500/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27500_1-webres.jpg"}
@@ -542,7 +542,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27600_1-webres.jpg"}
@@ -574,7 +574,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27700_1-webres.jpg"}
@@ -606,7 +606,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27800_1-webres.jpg"}
@@ -638,7 +638,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-27900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-27900_1-webres.jpg"}
@@ -670,7 +670,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28000/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-28000_1-webres.jpg"}
@@ -702,7 +702,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28100/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-28100_1-webres.jpg"}
@@ -744,7 +744,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28200/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28200/2017:1", "controllerName" : "St Goran", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-28200_1-webres.jpg"}
@@ -786,7 +786,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28300/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-28300_1-webres.jpg"}
@@ -818,7 +818,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28400/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-28400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-28400_1-webres.jpg"}
@@ -860,7 +860,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28500/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-28500_1-webres.jpg"}
@@ -892,7 +892,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28550/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28550/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-28550_1-webres.jpg"}
@@ -934,7 +934,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-28600_1-webres.jpg"}
@@ -966,7 +966,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-28700_1-webres.jpg"}
@@ -998,7 +998,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28800/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-28800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-28800_1-webres.jpg"}
@@ -1040,7 +1040,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-28900/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-28900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-28900_1-webres.jpg"}
@@ -1082,7 +1082,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29000/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29000_1-webres.jpg"}
@@ -1114,7 +1114,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29100/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29100_1-webres.jpg"}
@@ -1146,7 +1146,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29200/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29200_1-webres.jpg"}
@@ -1178,7 +1178,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29400/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29400_1-webres.jpg"}
@@ -1210,7 +1210,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29500/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29500_1-webres.jpg"}
@@ -1242,7 +1242,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29501/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29501/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29501_1-webres.jpg"}
@@ -1274,7 +1274,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29800_1-webres.jpg"}
@@ -1306,7 +1306,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-29900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-29900_1-webres.jpg"}
@@ -1338,7 +1338,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-30000/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-30000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-30000_1-webres.jpg"}
@@ -1370,7 +1370,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30100/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30100_1-webres.jpg"}
@@ -1402,7 +1402,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30200/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30200_1-webres.jpg"}
@@ -1444,7 +1444,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30300/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30300_1-webres.jpg"}
@@ -1486,7 +1486,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30400/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30400_1-webres.jpg"}
@@ -1528,7 +1528,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30500/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30500_1-webres.jpg"}
@@ -1570,7 +1570,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30600_1-webres.jpg"}
@@ -1602,7 +1602,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30700_1-webres.jpg"}
@@ -1634,7 +1634,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30800_1-webres.jpg"}
@@ -1666,7 +1666,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-30900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-30900_1-webres.jpg"}
@@ -1698,7 +1698,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31000/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-31000_1-webres.jpg"}
@@ -1730,7 +1730,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31100/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-31100_1-webres.jpg"}
@@ -1762,7 +1762,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31200/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-31200_1-webres.jpg"}
@@ -1794,7 +1794,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31300/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-31300_1-webres.jpg"}
@@ -1826,7 +1826,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31400/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3105-31400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3105-31400_1-webres.jpg"}
@@ -1858,7 +1858,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-31500/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3103-31500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3103-31500_1-webres.jpg"}
@@ -1890,7 +1890,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-31600_1-webres.jpg"}
@@ -1922,7 +1922,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31650/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31650/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-31650_1-webres.jpg"}
@@ -1954,7 +1954,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-31700_1-webres.jpg"}
@@ -1986,7 +1986,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31800/2017:1", "controllerName" : "Perranzabuloe", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-31800_1-webres.jpg"}
@@ -2018,7 +2018,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-31900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-31900_1-webres.jpg"}
@@ -2050,7 +2050,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-32000/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3102-32000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3102-32000_1-webres.jpg"}
@@ -2088,7 +2088,7 @@ http_interactions:
                 , "nirsRef" : "12345678", "som_recordDateTime" : {"_value" : "2017-03-31T11:24:55", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-03-27T14:49:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32100/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32100/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32100_1-webres.jpg"}
@@ -2130,7 +2130,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32200/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32200_1-webres.jpg"}
@@ -2162,7 +2162,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32300/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32300_1-webres.jpg"}
@@ -2194,7 +2194,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32310/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32310/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32310_1-webres.jpg"}
@@ -2226,7 +2226,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32320/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32320/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32320_1-webres.jpg"}
@@ -2258,7 +2258,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32330/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32330/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32330_1-webres.jpg"}
@@ -2290,7 +2290,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32340/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32340/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32340_1-webres.jpg"}
@@ -2332,7 +2332,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32400/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32400_1-webres.jpg"}
@@ -2364,7 +2364,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32500/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3106-32500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3106-32500_1-webres.jpg"}
@@ -2396,7 +2396,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32550/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32550/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-32550_1-webres.jpg"}
@@ -2428,7 +2428,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32600/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-32600_1-webres.jpg"}
@@ -2460,7 +2460,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-32700_1-webres.jpg"}
@@ -2492,7 +2492,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32800/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32800/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-32800_1-webres.jpg"}
@@ -2524,7 +2524,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32900/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-32900/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-32900_1-webres.jpg"}
@@ -2556,7 +2556,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33000/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33000/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33000_1-webres.jpg"}
@@ -2598,7 +2598,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33200/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33200/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33200_1-webres.jpg"}
@@ -2630,7 +2630,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33300/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33300/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33300_1-webres.jpg"}
@@ -2683,7 +2683,7 @@ http_interactions:
                 , "nirsRef" : "01451937", "som_recordDateTime" : {"_value" : "2017-04-12T09:37:47", "_datatype" : "dateTime"}
                 , "startOfIncident" : {"_value" : "2017-04-06T16:18:00", "_datatype" : "dateTime"}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33350/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33350/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33350_1-webres.jpg"}
@@ -2715,7 +2715,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33360/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33360/2017:1", "controllerName" : "St. Gennys", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33360_1-webres.jpg"}
@@ -2757,7 +2757,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33400/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33400/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33400_1-webres.jpg"}
@@ -2789,7 +2789,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33500/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33500/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33500_1-webres.jpg"}
@@ -2831,7 +2831,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33600/2017:1", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33600/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33600_1-webres.jpg"}
@@ -2873,7 +2873,7 @@ http_interactions:
                 }
                 , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
               }
-              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33700/2017:1", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk3104-33700/2017:1", "controllerName" : "Cornwall", "pollutionRiskForecasting" : {"_value" : "false", "_datatype" : "boolean"}
                 , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
                 , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
                 , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk3104-33700_1-webres.jpg"}
@@ -2894,5 +2894,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:31 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:25 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_locales.yml
+++ b/test/fixtures/vcr_cassettes/test_locales.yml
@@ -21,25 +21,25 @@ http_interactions:
       Access-Control-Allow-Origin:
       - "*"
       Age:
-      - '1'
+      - '3'
       Content-Location:
       - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 15:39:49 GMT
+      - Fri, 02 Feb 2018 17:21:32 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 15:42:47 GMT
+      - Fri, 02 Feb 2018 17:24:28 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '114'
+      - '135'
       Content-Length:
-      - '57852'
+      - '58274'
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
+  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_locales.yml
+++ b/test/fixtures/vcr_cassettes/test_locales.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600&country=http://data.ordnancesurvey.co.uk/id/country/england
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water?_pageSize=600
     body:
       encoding: US-ASCII
       string: ''
@@ -20,30 +20,32 @@ http_interactions:
     headers:
       Access-Control-Allow-Origin:
       - "*"
+      Age:
+      - '1'
       Content-Location:
-      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600
       Content-Type:
       - application/json
       Date:
-      - Wed, 31 Jan 2018 16:20:15 GMT
+      - Fri, 02 Feb 2018 15:39:49 GMT
       Etag:
-      - '"fa2d5bebcad82a90-gzip"'
+      - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Wed, 31 Jan 2018 16:23:14 GMT
+      - Fri, 02 Feb 2018 15:42:47 GMT
       Server:
-      - Server
+      - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '38'
-      Transfer-Encoding:
-      - chunked
+      - '114'
+      Content-Length:
+      - '57852'
       Connection:
       - keep-alive
     body:
       encoding: ASCII-8BIT
       string: |
-        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json?country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&country=http%3A%2F%2Fdata.ordnancesurvey.co.uk%2Fid%2Fcountry%2Fengland", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_metadata=all", "first" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600&_page=0", "isPartOf" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water.json", "hasPart" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water.json?_pageSize=600", "type" : ["http://purl.org/linked-data/api/vocab#ListEndpoint"]}
             , "items" : [{"_about" : "http://environment.data.gov.uk/id/bathing-water/ukc2102-03600", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366703", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366703", "label" : [{"_value" : "Companies House profile for Northumbrian Water Limited", "_lang" : "en"}
                   ]}
                 , "name" : {"_value" : "Northumbrian Water Limited", "_lang" : "en"}
@@ -10877,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Wed, 31 Jan 2018 16:20:15 GMT
+  recorded_at: Fri, 02 Feb 2018 15:39:49 GMT
 recorded_with: VCR 4.0.0

--- a/test/fixtures/vcr_cassettes/test_locales.yml
+++ b/test/fixtures/vcr_cassettes/test_locales.yml
@@ -27,19 +27,19 @@ http_interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 02 Feb 2018 17:21:32 GMT
+      - Fri, 02 Feb 2018 21:36:25 GMT
       Etag:
       - '"ea2bf6b49f898e6-gzip"'
       Expires:
-      - Fri, 02 Feb 2018 17:24:28 GMT
+      - Fri, 02 Feb 2018 21:39:23 GMT
       Server:
       - Apache
       Vary:
       - Accept,Accept-Encoding
       X-Response-Id:
-      - '135'
+      - '152'
       Content-Length:
-      - '58274'
+      - '57852'
       Connection:
       - keep-alive
     body:
@@ -10879,5 +10879,5 @@ http_interactions:
             ], "itemsPerPage" : 600, "page" : 0, "startIndex" : 1, "type" : ["http://purl.org/linked-data/api/vocab#Page"]}
         }
     http_version: 
-  recorded_at: Fri, 02 Feb 2018 17:21:32 GMT
+  recorded_at: Fri, 02 Feb 2018 21:36:26 GMT
 recorded_with: VCR 4.0.0

--- a/test/models/bathing_water_test.rb
+++ b/test/models/bathing_water_test.rb
@@ -25,5 +25,12 @@ class BathingWaterTest < ActiveSupport::TestCase
         bw.name.must_equal('Clevedon Beach')
       end
     end
+
+    describe '#controller_name' do
+      it 'should return the name of the bw controller' do
+        bw = BathingWater.new(bw_fixture)
+        bw.controller_name.must_equal('North Somerset')
+      end
+    end
   end
 end

--- a/test/presenters/workflow_test.rb
+++ b/test/presenters/workflow_test.rb
@@ -52,8 +52,8 @@ class WorkflowTest < ActiveSupport::TestCase
       it 'should select preview when all information is complete' do
         Workflow.next_incomplete_step(design: true, eubwid: '123', 'bwmgr-email': 'foo',
                                       'bwmgr-name': 'bar', 'bwmgr-phone': '',
-                                      'no-hist': true, 'no-map': false, 'no-prf': true,
-                                      'no-logo': false)
+                                      'show-hist': true, 'show-map': false, 'show-prf': true,
+                                      'show-logo': false)
                 .must_equal :preview
       end
     end

--- a/test/services/bathing_water_search_test.rb
+++ b/test/services/bathing_water_search_test.rb
@@ -1,0 +1,74 @@
+# frozen-string-literal: true
+
+require 'test_helper'
+
+# Unit tests on bathing water search service
+class BathingWaterSearchTest < ActiveSupport::TestCase
+  describe 'BathingWaterSearch' do
+    describe '#validate' do
+      it 'should allow a search term that is letters and numbers' do
+        params = ActionController::Parameters.new(search: 'foo-99').permit!
+        flash = {}
+
+        svc = BathingWaterSearch.new
+        valid_params = svc.validate(params, flash)
+
+        valid_params[:search].must_equal 'foo-99'
+        flash.must_be_empty
+      end
+
+      it 'should reject an empty search term' do
+        params = ActionController::Parameters.new(search: '').permit!
+        flash = {}
+
+        svc = BathingWaterSearch.new
+        valid_params = svc.validate(params, flash)
+
+        valid_params[:search].must_be_nil
+        flash[:errors].must_include('Empty search input')
+      end
+
+      it 'should reject an invalid search term' do
+        params = ActionController::Parameters.new(search: 'foo.*').permit!
+        flash = {}
+
+        svc = BathingWaterSearch.new
+        valid_params = svc.validate(params, flash)
+
+        valid_params[:search].must_be_nil
+        flash[:errors].must_include('Non-permitted characters in search input')
+      end
+
+      it 'should find bathing waters whose names match a search term' do
+        VCR.use_cassette('bathing_waters_api') do
+          svc = BathingWaterSearch.new
+          results = svc.search('cleve')
+          results[:by_name].wont_be_empty
+          results[:by_name].map(&:name).must_include('Clevedon Beach')
+        end
+      end
+
+      it 'should find bathing waters whose ID matches a search term' do
+        VCR.use_cassette('bathing_waters_api') do
+          svc = BathingWaterSearch.new
+          results = svc.search('ukc2102-03600')
+          results[:by_name].must_be_empty
+          results[:by_id].wont_be_empty
+          results[:by_id].map(&:name).must_include('Spittal')
+        end
+      end
+
+      it 'should find bathing waters whose controller name matches a search term' do
+        VCR.use_cassette('bathing_waters_api') do
+          svc = BathingWaterSearch.new
+          results = svc.search('northumberland')
+          results[:by_id].must_be_empty
+          results[:by_controller].length.must_be :>=, 12
+          results[:by_controller]
+            .first['latestProfile.controllerName']
+            .must_equal 'Northumberland'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a simple form for allowing the user to select the optional parts of the bathing water sign. Currently these are:

- PRF summary
- annual compliance history
- sampling point map
- EA logo