### PR TITLE
Feature/page orientation

### DIFF
--- a/app/controllers/signage_design_controller.rb
+++ b/app/controllers/signage_design_controller.rb
@@ -18,7 +18,11 @@ class SignageDesignController < ApplicationController
   end
 
   def permitted_params
-    params.permit(*Workflow::ALL_PARAMS)
+    params.permit(*all_permitted_param_names)
+  end
+
+  def all_permitted_param_names
+    %i[page_orientation].concat(Workflow::ALL_PARAMS)
   end
 
   def search

--- a/app/presenters/bwq_sign.rb
+++ b/app/presenters/bwq_sign.rb
@@ -31,4 +31,21 @@ class BwqSign
   def show_preview?
     next_workflow_step == :preview
   end
+
+  def landscape?
+    params[:page_orientation] != 'portrait'
+  end
+
+  def page_orientation
+    {
+      current: landscape? ? 'landscape' : 'portrait',
+      current_icon: landscape? ? 'fa-picture-o' : 'fa-file-picture-o',
+      alt: landscape? ? 'portrait' : 'landscape',
+      alt_icon: landscape? ? 'fa-file-picture-o' : 'fa-picture-o'
+    }
+  end
+
+  def with_query_params(options)
+    params.to_h.merge(options)
+  end
 end

--- a/app/views/signage_design/_bathing_water_sign.html.haml
+++ b/app/views/signage_design/_bathing_water_sign.html.haml
@@ -1,5 +1,5 @@
 %article#development-container.c-sign-preview
-  %div.c-sign-preview--landscape
+  %div.c-sign-preview{ class: "c-sign-preview--#{@view_state.page_orientation[:current]}" }
     %section.c-content-row__head
       .o-content-unit__1-1
         %h1

--- a/app/views/signage_design/_preview.html.haml
+++ b/app/views/signage_design/_preview.html.haml
@@ -1,3 +1,4 @@
+- page_orientation = @view_state.page_orientation
 .o-page-container
   .o-grid-row
     .o-grid-column__two-thirds
@@ -8,9 +9,13 @@
         See a preview of your sign below. You can also:
       %ul
         %li
-          change from landscape orientation <i class='fa fa-picture-o'></i> to
-          %a{href:'#'}
-            portrait orientation <i class='fa fa-file-picture-o'></i>
+          change from #{page_orientation[:current]} orientation
+          %i.fa{ class: page_orientation[:current_icon] }
+          to
+          = link_to(@view_state.with_query_params(page_orientation: page_orientation[:alt])) do
+            #{page_orientation[:alt]} orientation
+            %i.fa{ class: page_orientation[:alt_icon] }
+
         %li
           %a{ href: '#' }
             select a different bathing water

--- a/test/controllers/signage_design_controller_test.rb
+++ b/test/controllers/signage_design_controller_test.rb
@@ -132,4 +132,25 @@ class SignageDesignControllerTest < ActionDispatch::IntegrationTest
     visit(root_path(design: true))
     page.wont_have_selector('#development-container')
   end
+
+  it 'should show the preview page in landscape mode by default' do
+    VCR.use_cassette('bathing_water_clevedon_lookup') do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000', 'bwmgr-name': 'North Somerset',
+                      'bwmgr-phone': '', 'bwmgr-email': '', 'show-prf': 'no',
+                      'show-hist': 'yes', 'show-logo': 'yes', 'show-map': 'yes'))
+      page.must_have_content('change from landscape orientation')
+    end
+  end
+
+  it 'should show the switch to portrait orientation on demand' do
+    VCR.use_cassette('bathing_water_clevedon_lookup', record: :new_episodes) do
+      visit(root_path(design: true, eubwid: 'ukk1202-36000', 'bwmgr-name': 'North Somerset',
+                      'bwmgr-phone': '', 'bwmgr-email': '', 'show-prf': 'no',
+                      'show-hist': 'yes', 'show-logo': 'yes', 'show-map': 'yes'))
+      page.must_have_selector('.c-sign-preview--landscape')
+      click_on('portrait orientation')
+      page.must_have_content('change from portrait orientation')
+      page.must_have_selector('.c-sign-preview--portrait')
+    end
+  end
 end

--- a/test/fixtures/vcr_cassettes/bathing_water_clevedon_lookup.yml
+++ b/test/fixtures/vcr_cassettes/bathing_water_clevedon_lookup.yml
@@ -91,4 +91,93 @@ http_interactions:
         }
     http_version: 
   recorded_at: Fri, 02 Feb 2018 21:37:40 GMT
+- request:
+    method: get
+    uri: http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime,latestSampleAssessment.sampleYear.ordinalYear,latestSampleAssessment.escherichiaColiCount.*,latestSampleAssessment.intestinalEnterococciCount.*,latestProfile.webResImage,latestProfile.pollutionRiskForecasting,latestProfile.seasonStartDate,latestProfile.seasonFinishDate,latestProfile.controllerName,latestComplianceAssessment.sampleYear.ordinalYear,latestRiskPrediction.*
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.13.1
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Origin:
+      - "*"
+      Content-Location:
+      - http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 06 Feb 2018 10:31:32 GMT
+      Etag:
+      - '"aca12b6eb0f4bada-gzip"'
+      Expires:
+      - Tue, 06 Feb 2018 10:34:32 GMT
+      Server:
+      - Server
+      Vary:
+      - Accept,Accept-Encoding
+      X-Response-Id:
+      - '212'
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        { "format" : "linked-data-api", "version" : "0.2", "result" : {"_about" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "definition" : "http://ea-rbwd-staging.epimorphics.net/meta/doc/bathing-water/_eubwid.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A", "extendedMetadataVersion" : "http://ea-rbwd-staging.epimorphics.net/doc/bathing-water/ukk1202-36000.json?_properties=latestSampleAssessment.sampleDateTime.inXSDDateTime%2ClatestSampleAssessment.sampleYear.ordinalYear%2ClatestSampleAssessment.escherichiaColiCount.%2A%2ClatestSampleAssessment.intestinalEnterococciCount.%2A%2ClatestProfile.webResImage%2ClatestProfile.pollutionRiskForecasting%2ClatestProfile.seasonStartDate%2ClatestProfile.seasonFinishDate%2ClatestProfile.controllerName%2ClatestComplianceAssessment.sampleYear.ordinalYear%2ClatestRiskPrediction.%2A&_metadata=all", "primaryTopic" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/ukk1202-36000", "appointedSewerageUndertaker" : {"_about" : "http://business.data.gov.uk/id/company/02366648", "companyProfile" : {"_about" : "http://business.data.gov.uk/companies/profile/02366648", "label" : [{"_value" : "Companies House profile for Wessex Water Services Limited", "_lang" : "en"}
+                  ]}
+                , "name" : {"_value" : "Wessex Water Services Limited", "_lang" : "en"}
+              }
+              , "country" : {"_about" : "http://data.ordnancesurvey.co.uk/id/country/england", "name" : {"_value" : "England", "_lang" : "en"}
+              }
+              , "district" : [{"_about" : "http://data.ordnancesurvey.co.uk/id/7000000000025504", "name" : {"_value" : "North Somerset", "_lang" : "en"}
+              }
+              , "http://statistics.data.gov.uk/id/statistical-geography/E06000024"], "envelope" : {"_about" : "http://location.data.gov.uk/so/common/Envelope/bwpf.eaew/ukk1202-36000:1", "label" : [{"_value" : "Map bounds for Clevedon Beach", "_lang" : "en"}
+                ]}
+              , "eubwidNotation" : "ukk1202-36000", "latestComplianceAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/compliance-rBWD/point/36000/year/2016", "complianceClassification" : {"_about" : "http://environment.data.gov.uk/def/bwq-cc-2015/2", "name" : {"_value" : "Good", "_lang" : "en"}
+                }
+                , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
+              }
+              , "latestProfile" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-profile/ukk1202-36000/2017:1", "controllerName" : "North Somerset", "pollutionRiskForecasting" : {"_value" : "true", "_datatype" : "boolean"}
+                , "seasonFinishDate" : {"_value" : "2017-09-30", "_datatype" : "date"}
+                , "seasonStartDate" : {"_value" : "2017-05-01", "_datatype" : "date"}
+                , "webResImage" : "http://environment.data.gov.uk/media/image/bathing-water-profile/ukk1202-36000_1-webres.jpg"}
+              , "latestRiskPrediction" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction/point/36000/date/20171006-144034", "comment" : {"_value" : "No water quality warning issued", "_lang" : "en"}
+                , "dataset" : ["http://environment.data.gov.uk/data/bathing-water-quality/eaew/stp-risk-prediction", "http://environment.data.gov.uk/data/bathing-water-quality/stp-risk-prediction"], "expiresAt" : {"_value" : "2017-10-07T08:29:00", "_datatype" : "dateTime"}
+                , "predictedAt" : {"_value" : "2017-10-06T08:30:00", "_datatype" : "dateTime"}
+                , "predictedOn" : {"_value" : "2017-10-06", "_datatype" : "date"}
+                , "publishedAt" : {"_value" : "2017-10-06T14:40:34", "_datatype" : "dateTime"}
+                , "riskLevel" : {"_about" : "http://environment.data.gov.uk/def/bwq-stp/normal", "name" : {"_value" : "normal", "_lang" : "en"}
+                }
+                , "source" : "http://environment.data.gov.uk/sources/bwq/eaew/input/forecasts-publishTesting-2017-10-06_14-40-34_772-0584.csv#row=0135", "stp_bathingWater" : "http://environment.data.gov.uk/id/bathing-water/ukk1202-36000", "stp_samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/36000", "easting" : 339914.0, "lat" : 51.4377009394295, "long" : -2.86583928659229, "name" : {"_value" : "Sampling point at Clevedon Beach", "_lang" : "en"}
+                  , "northing" : 171322.0}
+                , "type" : ["http://environment.data.gov.uk/def/bwq-stp/RiskPrediction"]}
+              , "latestSampleAssessment" : {"_about" : "http://environment.data.gov.uk/data/bathing-water-quality/in-season/sample/point/36000/date/20160922/time/100400/recordDate/20160922", "escherichiaColiCount" : 36, "intestinalEnterococciCount" : 10, "sampleDateTime" : {"_about" : "http://reference.data.gov.uk/id/gregorian-instant/2016-09-22T10:04:00", "inXSDDateTime" : {"_value" : "2016-09-22T10:04:00", "_datatype" : "dateTime"}
+                }
+                , "sampleYear" : {"_about" : "http://reference.data.gov.uk/id/year/2016", "ordinalYear" : 2016}
+              }
+              , "name" : {"_value" : "Clevedon Beach", "_lang" : "en"}
+              , "regionalOrganization" : {"_about" : "http://reference.data.gov.uk/id/public-body/environment-agency/unit/south-west-south-west-office", "name" : {"_value" : "South West", "_lang" : "en"}
+              }
+              , "sameAs" : "http://environment.data.gov.uk/id/bathing-water/clevedon-beach", "samplingPoint" : {"_about" : "http://location.data.gov.uk/so/ef/SamplingPoint/bwsp.eaew/36000", "easting" : 339914.0, "lat" : 51.4377009394295, "long" : -2.86583928659229, "name" : {"_value" : "Sampling point at Clevedon Beach", "_lang" : "en"}
+                , "northing" : 171322.0}
+              , "sedimentTypesPresent" : ["http://environment.data.gov.uk/def/bathing-water/sand-sediment", "http://environment.data.gov.uk/def/bathing-water/shingle-sediment"], "type" : ["http://environment.data.gov.uk/def/bathing-water/BathingWater", "http://environment.data.gov.uk/def/bathing-water/TransitionalBathingWater"], "uriSet" : {"_about" : "http://environment.data.gov.uk/id/bathing-water/", "label" : [{"_value" : "Bathing waters monitored by the Environment Agency for England and Wales.", "_lang" : "en"}
+                ]}
+              , "waterQualityImpactedByHeavyRain" : true, "yearDesignated" : "http://reference.data.gov.uk/id/year/1988", "zoneOfInfluence" : {"_about" : "http://location.data.gov.uk/so/ef/ZoneOfInfluence/bwzoi.eaew/ukk1202-36000:1", "name" : {"_value" : "Zone of influence at Clevedon Beach", "_lang" : "en"}
+              }
+            }
+            , "type" : ["http://purl.org/linked-data/api/vocab#ItemEndpoint", "http://purl.org/linked-data/api/vocab#Page"]}
+        }
+    http_version: 
+  recorded_at: Tue, 06 Feb 2018 10:31:32 GMT
 recorded_with: VCR 4.0.0

--- a/test/presenters/bwq_sign_test.rb
+++ b/test/presenters/bwq_sign_test.rb
@@ -58,4 +58,32 @@ class BwqSignTest < ActiveSupport::TestCase
       assert BwqSign.new(params: ActionController::Parameters.new(base).permit!).show_preview?
     end
   end
+
+  describe 'page orientation' do
+    it 'should return the default page orientation if not specified' do
+      po = BwqSign.new(params: ActionController::Parameters.new).page_orientation
+      po[:current].must_equal('landscape')
+      po[:alt].must_equal('portrait')
+      po[:current_icon].wont_be_nil
+      po[:alt_icon].wont_be_nil
+    end
+
+    it 'should return the page orientation if not specified' do
+      params = ActionController::Parameters.new(page_orientation: 'portrait').permit!
+      po = BwqSign.new(params: params).page_orientation
+      po[:current].must_equal('portrait')
+      po[:alt].must_equal('landscape')
+      po[:current_icon].wont_be_nil
+      po[:alt_icon].wont_be_nil
+    end
+  end
+
+  describe '#with_query_params' do
+    it 'should merge the given params with the current query params' do
+      params = ActionController::Parameters.new(page_orientation: 'portrait', design: true).permit!
+      BwqSign.new(params: params)
+             .with_query_params(page_orientation: 'landscape', foo: 'bar')
+             .must_equal('page_orientation' => 'landscape', 'design' => true, 'foo' => 'bar')
+    end
+  end
 end

--- a/test/presenters/bwq_sign_test.rb
+++ b/test/presenters/bwq_sign_test.rb
@@ -42,4 +42,20 @@ class BwqSignTest < ActiveSupport::TestCase
       bwq_sign.search_results.must_equal(['miss piggy'])
     end
   end
+
+  describe 'preview' do
+    it 'should return true when the preview is visible' do
+      # not all page params are present
+      base = {
+        design: true, eubwid: '123', 'bwmgr-email': 'foo',
+        'bwmgr-name': 'bar', 'bwmgr-phone': '',
+        'show-hist': true, 'show-map': false, 'show-prf': true
+      }
+      refute BwqSign.new(params: ActionController::Parameters.new(base).permit!).show_preview?
+
+      # add the missing param
+      base[:'show-logo'] = true
+      assert BwqSign.new(params: ActionController::Parameters.new(base).permit!).show_preview?
+    end
+  end
 end

--- a/test/presenters/bwq_sign_test.rb
+++ b/test/presenters/bwq_sign_test.rb
@@ -13,7 +13,9 @@ class BwqSignTest < ActiveSupport::TestCase
         bwq_sign.params.must_equal mock_params
       end
     end
+  end
 
+  describe 'workflow' do
     describe '#next_workflow_step' do
       it 'should calculate the next workflow step given the parameters' do
         params = ActionController::Parameters.new(design: true).permit!
@@ -21,6 +23,23 @@ class BwqSignTest < ActiveSupport::TestCase
 
         bwq_sign.next_workflow_step.must_equal :search
       end
+    end
+  end
+
+  describe 'search' do
+    it 'should return the search term from the params' do
+      params = ActionController::Parameters.new(search: 'kermit').permit!
+      bwq_sign = BwqSign.new(params: params)
+      bwq_sign.search_term.must_equal('kermit')
+    end
+
+    it 'should delegate searching to the search service' do
+      search_service = mock('search_service')
+      search_service.expects(:search).with('kermit').returns(['miss piggy'])
+
+      params = ActionController::Parameters.new(search: 'kermit').permit!
+      bwq_sign = BwqSign.new(params: params, search: search_service)
+      bwq_sign.search_results.must_equal(['miss piggy'])
     end
   end
 end


### PR DESCRIPTION
PR to merge the page orientation feature into develop. This feature allows the user to specify that the sign should be in portrait or landscape orientation, and adjusts the preview accordingly.