### PR TITLE
Feature/show prf

### DIFF
--- a/app/assets/stylesheets/_sign-layout.scss
+++ b/app/assets/stylesheets/_sign-layout.scss
@@ -89,6 +89,14 @@ $rowHeightFoot: 100% - ($rowHeightHead + $rowHeightAbout + $rowHeightInfo);
   text-align: center;
 }
 
+/* one block on a row of one compact block */
+.o-content-unit__1-1c {
+  @extend .o-content-unit__1-1;
+  width: 66%;
+  text-align: left;
+  padding: 1em;
+}
+
 /* row of two blocks */
 .o-content-unit__1-2, .o-content-unit__2-2 {
   max-height: 100%;

--- a/app/models/bathing_water.rb
+++ b/app/models/bathing_water.rb
@@ -43,4 +43,8 @@ class BathingWater < LdaResource
 
     stmts
   end
+
+  def prf_statement
+    self['latestProfile.signPRFSummary'].val
+  end
 end

--- a/app/presenters/bwq_sign.rb
+++ b/app/presenters/bwq_sign.rb
@@ -78,7 +78,7 @@ class BwqSign
 
   # Only show PRF summary if the BW is in PRF programmne, and user ticked 'yes'
   def show_prf?
-    bathing_water['pollutionRiskForecasting'].val == 'true' &&
+    bathing_water['latestProfile.pollutionRiskForecasting'].val == 'true' &&
       params[:'show-prf'] == 'yes'
   end
 end

--- a/app/presenters/bwq_sign.rb
+++ b/app/presenters/bwq_sign.rb
@@ -75,4 +75,10 @@ class BwqSign
       srcset: "https://environment.data.gov.uk/bwq/profiles/images/#{image_root[:src]}.svg"
     }
   end
+
+  # Only show PRF summary if the BW is in PRF programmne, and user ticked 'yes'
+  def show_prf?
+    bathing_water['pollutionRiskForecasting'].val == 'true' &&
+      params[:'show-prf'] == 'yes'
+  end
 end

--- a/app/views/signage_design/_bathing_water_sign.html.haml
+++ b/app/views/signage_design/_bathing_water_sign.html.haml
@@ -23,8 +23,9 @@
 
       - if @view_state.show_prf?
         .o-content-unit__2-2.o-content-unit__box
-          %h2 Pollution Risk Forecast
-          %p This bathing water is subject to short term pollution. The Environment Agency makes daily pollution risk forecasts based on rainfall patterns. A pollution risk warning is issued if heavy rainfall occurs, enabling bathers to avoid periods when bathing water quality may be reduced. This can last between one and three days. In 2017 warnings were issued at this bathing water on XX days.
+          %h2 Short-term pollution
+          %p
+            = @view_state.bathing_water.prf_statement
 
     %section.c-content-row__info
       .o-content-unit__1-3.o-content-unit__box

--- a/app/views/signage_design/_bathing_water_sign.html.haml
+++ b/app/views/signage_design/_bathing_water_sign.html.haml
@@ -12,7 +12,8 @@
             = @view_state.monitoring_statement
 
     %section.c-content-row__about
-      .o-content-unit__1-2.o-content-unit__box
+      - pollution_sources_cls = @view_state.show_prf? ? 'o-content-unit__1-2' : 'o-content-unit__1-1c'
+      .o-content-unit__box{ class: pollution_sources_cls }
         %h2
           Water quality at
           = @view_state.bathing_water.name
@@ -20,9 +21,10 @@
           %p
             = stmt
 
-      .o-content-unit__2-2.o-content-unit__box
-        %h2 Pollution Risk Forecast
-        %p This bathing water is subject to short term pollution. The Environment Agency makes daily pollution risk forecasts based on rainfall patterns. A pollution risk warning is issued if heavy rainfall occurs, enabling bathers to avoid periods when bathing water quality may be reduced. This can last between one and three days. In 2017 warnings were issued at this bathing water on XX days.
+      - if @view_state.show_prf?
+        .o-content-unit__2-2.o-content-unit__box
+          %h2 Pollution Risk Forecast
+          %p This bathing water is subject to short term pollution. The Environment Agency makes daily pollution risk forecasts based on rainfall patterns. A pollution risk warning is issued if heavy rainfall occurs, enabling bathers to avoid periods when bathing water quality may be reduced. This can last between one and three days. In 2017 warnings were issued at this bathing water on XX days.
 
     %section.c-content-row__info
       .o-content-unit__1-3.o-content-unit__box

--- a/test/models/bathing_water_test.rb
+++ b/test/models/bathing_water_test.rb
@@ -59,5 +59,13 @@ class BathingWaterTest < ActiveSupport::TestCase
         stmts[1].must_match(/This bathing water beach often has patches of seaweed/)
       end
     end
+
+    describe '#prf_statement' do
+      it 'should get the text of the pre-prepared PRF statement' do
+        BathingWater.new(bw_fixture)
+                    .prf_statement
+                    .must_match(/This bathing water is subject to short term pollution./)
+      end
+    end
   end
 end

--- a/test/presenters/bwq_sign_test.rb
+++ b/test/presenters/bwq_sign_test.rb
@@ -109,4 +109,36 @@ class BwqSignTest < ActiveSupport::TestCase
              .must_equal('good water quality')
     end
   end
+
+  describe '#show_prf?' do
+    it 'should return true if the BW is in PRF, and the user ticked "yes" when asked' do
+      mock_flag = mock('Value')
+      mock_flag.expects(:val).returns('true')
+      mock_bw = mock('BathingWater')
+      mock_bw.expects(:[]).returns(mock_flag)
+      params = ActionController::Parameters.new('show-prf': 'yes')
+
+      assert BwqSign.new(bathing_water: mock_bw, params: params).show_prf?
+    end
+
+    it 'should return false if the BW is not in PRF, even if the user ticked "yes" when asked' do
+      mock_flag = mock('Value')
+      mock_flag.expects(:val).returns('false')
+      mock_bw = mock('BathingWater')
+      mock_bw.expects(:[]).returns(mock_flag)
+      params = ActionController::Parameters.new('show-prf': 'yes')
+
+      refute BwqSign.new(bathing_water: mock_bw, params: params).show_prf?
+    end
+
+    it 'should return false if the BW is in PRF, but the user ticked "no" when asked' do
+      mock_flag = mock('Value')
+      mock_flag.expects(:val).returns('true')
+      mock_bw = mock('BathingWater')
+      mock_bw.expects(:[]).returns(mock_flag)
+      params = ActionController::Parameters.new('show-prf': 'no')
+
+      refute BwqSign.new(bathing_water: mock_bw, params: params).show_prf?
+    end
+  end
 end


### PR DESCRIPTION
This PR merges the features of optionally selecting the PRF summary according to the user's preference, and of optionally including the PRF summary if it is defined (and, by implication, omitting that content unit from the sign for bathing waters not in PRF)